### PR TITLE
Inject env vars during build

### DIFF
--- a/src/MainMenu.jsx
+++ b/src/MainMenu.jsx
@@ -184,7 +184,7 @@ function ButtonArea({ hasCurrentDataset, showMap }) {
 							category: "Help",
 							action: "Help Button Clicked",
 						});
-						window.location.href = config.kapta.askTheTeamURL;
+						window.location.href = process.env.ASK_URL;
 					}}
 				>
 					{t("asktheteam")}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,9 @@ module.exports = {
 		],
 	},
 	plugins: [
+		new webpack.EnvironmentPlugin({
+			ASK_URL: "https://wa.me/+34678380944?"
+		}),
 		new webpack.ProvidePlugin({
 			L: "leaflet",
 		}),


### PR DESCRIPTION
Using the webpack EnvironmentPlugin we can inject variables at build time. The example provided so far is for the askTheTeamURL. By setting 

`export ASK_URL="https://www.google.com"`

before running npm run build you can change the URL from the default provided in the plugin.