### PR TITLE
fixing amplify backend version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
 	"packages": {
 		"": {
 			"dependencies": {
+				"@aws-amplify/backend": "^1.3.0",
 				"@aws-sdk/client-cognito-identity-provider": "^3.583.0",
 				"@fortawesome/fontawesome-svg-core": "^6.5.2",
 				"@fortawesome/free-brands-svg-icons": "^6.5.2",
 				"@fortawesome/free-regular-svg-icons": "^6.5.2",
 				"@fortawesome/free-solid-svg-icons": "^6.5.2",
 				"@fortawesome/react-fontawesome": "^0.2.2",
-				"aws-amplify": "^6.6.2",
 				"copy-webpack-plugin": "^12.0.2",
 				"html2canvas": "^1.4.1",
 				"i18next": "^23.14.0",
@@ -46,7 +46,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
 			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -55,145 +54,1273 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@aws-amplify/analytics": {
-			"version": "7.0.49",
-			"resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.49.tgz",
-			"integrity": "sha512-+HLuvrbTAVhsMtMpwZuiGVULM7NqSoy6+gByi3NodZjMFvIQX6SvbZlGdDGjT5vYb8r3GSLRbgvGnf2VvfTTFA==",
+		"node_modules/@ardatan/aggregate-error": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz",
+			"integrity": "sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==",
 			"dependencies": {
-				"@aws-sdk/client-firehose": "3.621.0",
-				"@aws-sdk/client-kinesis": "3.621.0",
-				"@aws-sdk/client-personalize-events": "3.621.0",
-				"@smithy/util-utf8": "2.0.0",
-				"tslib": "^2.5.0"
+				"tslib": "~2.0.1"
 			},
-			"peerDependencies": {
-				"@aws-amplify/core": "^6.1.0"
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"node_modules/@aws-amplify/analytics/node_modules/@smithy/is-array-buffer": {
+		"node_modules/@ardatan/aggregate-error/node_modules/tslib": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+			"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+		},
+		"node_modules/@ardatan/relay-compiler": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.0.tgz",
+			"integrity": "sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==",
+			"dependencies": {
+				"@babel/core": "^7.14.0",
+				"@babel/generator": "^7.14.0",
+				"@babel/parser": "^7.14.0",
+				"@babel/runtime": "^7.0.0",
+				"@babel/traverse": "^7.14.0",
+				"@babel/types": "^7.0.0",
+				"babel-preset-fbjs": "^3.4.0",
+				"chalk": "^4.0.0",
+				"fb-watchman": "^2.0.0",
+				"fbjs": "^3.0.0",
+				"glob": "^7.1.1",
+				"immutable": "~3.7.6",
+				"invariant": "^2.2.4",
+				"nullthrows": "^1.1.1",
+				"relay-runtime": "12.0.0",
+				"signedsource": "^1.0.0",
+				"yargs": "^15.3.1"
+			},
+			"bin": {
+				"relay-compiler": "bin/relay-compiler"
+			},
+			"peerDependencies": {
+				"graphql": "*"
+			}
+		},
+		"node_modules/@ardatan/relay-compiler/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@ardatan/relay-compiler/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@ardatan/relay-compiler/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@ardatan/sync-fetch": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
+			"integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
+			"dependencies": {
+				"node-fetch": "^2.6.1"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@aws-amplify/appsync-modelgen-plugin": {
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.13.2.tgz",
+			"integrity": "sha512-gJrOHUnjSCevCNCfFinSB1fHDaOgWIjo+HDj68rcDlYBJz3S43R7yUFy5O3Lv6mQ5EbgNjUCNJ6rPLjMPuzaXw==",
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^1.18.8",
+				"@graphql-codegen/visitor-plugin-common": "^1.22.0",
+				"@graphql-tools/utils": "^6.0.18",
+				"chalk": "^3.0.0",
+				"change-case": "^4.1.1",
+				"graphql-transformer-common": "^4.25.1",
+				"lower-case-first": "^2.0.1",
+				"pluralize": "^8.0.0",
+				"strip-indent": "^3.0.0",
+				"ts-dedent": "^1.1.0"
+			},
+			"peerDependencies": {
+				"graphql": "^15.5.0"
+			}
+		},
+		"node_modules/@aws-amplify/appsync-modelgen-plugin/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@aws-amplify/appsync-modelgen-plugin/node_modules/chalk": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@aws-amplify/appsync-modelgen-plugin/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@aws-amplify/auth-construct": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/auth-construct/-/auth-construct-1.3.1.tgz",
+			"integrity": "sha512-1i2f5Wkv1fq4Eieb1UOaZfjchPAsExJxSZBOP89GnS2TU/PCceibZAFBUKUZ9FMqwItyxms/3fHUPHaBVlVqSA==",
+			"dependencies": {
+				"@aws-amplify/backend-output-schemas": "^1.1.0",
+				"@aws-amplify/backend-output-storage": "^1.1.2",
+				"@aws-amplify/plugin-types": "^1.2.2",
+				"@aws-sdk/util-arn-parser": "^3.568.0"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/auth-construct/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+			"integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/auth-construct/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/backend/-/backend-1.3.2.tgz",
+			"integrity": "sha512-kNlMRQ7A+QmoBNDcoQ5DSnuvf4XY6VJrcT8J8+xrsCbhaz4xRh8Ku6oPKeugMahdedxQNDxMGVoBW2UtEV1Xtg==",
+			"dependencies": {
+				"@aws-amplify/backend-auth": "^1.2.0",
+				"@aws-amplify/backend-data": "^1.1.4",
+				"@aws-amplify/backend-function": "^1.5.0",
+				"@aws-amplify/backend-output-schemas": "^1.3.0",
+				"@aws-amplify/backend-output-storage": "^1.1.2",
+				"@aws-amplify/backend-secret": "^1.1.2",
+				"@aws-amplify/backend-storage": "^1.2.1",
+				"@aws-amplify/client-config": "^1.4.0",
+				"@aws-amplify/data-schema": "^1.0.0",
+				"@aws-amplify/platform-core": "^1.1.0",
+				"@aws-amplify/plugin-types": "^1.3.0",
+				"@aws-sdk/client-amplify": "^3.624.0",
+				"lodash.snakecase": "^4.1.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-auth": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/backend-auth/-/backend-auth-1.2.0.tgz",
+			"integrity": "sha512-v1FYzq/NPuAlsGhUjNB+EdzxqcD3/MZKUlo+NC0kx++M0Bxt5V/I51ws7NL8EiB0nTr7GzZKl3fqK30vgJCJ9g==",
+			"dependencies": {
+				"@aws-amplify/auth-construct": "^1.3.1",
+				"@aws-amplify/backend-output-storage": "^1.1.2",
+				"@aws-amplify/plugin-types": "^1.3.0"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-auth/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+			"integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-auth/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-data": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/backend-data/-/backend-data-1.1.4.tgz",
+			"integrity": "sha512-qKK/t4VSH01P8OBA4yoNwqPKjVleQeQGZMo2S9voHMNk7C2hqBj0ztggMjhdiiVTYw8ZGIFMN1MFm05zdOJPqQ==",
+			"dependencies": {
+				"@aws-amplify/backend-output-schemas": "^1.1.0",
+				"@aws-amplify/backend-output-storage": "^1.1.2",
+				"@aws-amplify/data-construct": "^1.10.1",
+				"@aws-amplify/data-schema-types": "^1.1.1",
+				"@aws-amplify/plugin-types": "^1.2.2"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-data/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+			"integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-data/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/backend-function/-/backend-function-1.5.0.tgz",
+			"integrity": "sha512-bqcCntMiK8YJlTWYN9VtAKpqofPZYZfNx4Je3SCErGcBCIfXxe+3CPLsts1aQRIMaW1C3MFukK3MAzeMsfGOcQ==",
+			"dependencies": {
+				"@aws-amplify/backend-output-schemas": "^1.1.0",
+				"@aws-amplify/backend-output-storage": "^1.1.2",
+				"@aws-amplify/plugin-types": "^1.3.0",
+				"execa": "^8.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+			"integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/execa": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/get-stream": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/human-signals": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+			"engines": {
+				"node": ">=16.17.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/npm-run-path": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@aws-amplify/backend-function/node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@aws-amplify/backend-output-schemas": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/backend-output-schemas/-/backend-output-schemas-1.3.0.tgz",
+			"integrity": "sha512-uXzl0tnKY8zLpiLxdLd+hK5MtfABEKa0CxPuuDeiEh0ywQ+oGCtFwXXSkTP+fhnHehBuwOtjFmn/01vX+ufj6g==",
+			"peerDependencies": {
+				"zod": "^3.22.2"
+			}
+		},
+		"node_modules/@aws-amplify/backend-output-storage": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/backend-output-storage/-/backend-output-storage-1.1.2.tgz",
+			"integrity": "sha512-pKeYg33znqxRTWTDHp4D+w4lymhLeAMMn5ttlrYo2Kj2aSyI7TZs9pyhRa8cukhHgMuI51YBIZRejizjhIVXVA==",
+			"dependencies": {
+				"@aws-amplify/backend-output-schemas": "^1.2.0",
+				"@aws-amplify/platform-core": "^1.0.6",
+				"@aws-amplify/plugin-types": "^1.2.2"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-output-storage/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+			"integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-output-storage/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-secret": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/backend-secret/-/backend-secret-1.1.3.tgz",
+			"integrity": "sha512-DgicWDbKmBRNhXL6B5n2yJKW0ZrX6YrL5++UY8V+2RODCtCRgRfCDpy6/AULH8AsDRyT4NCgFqAXBG5pV+Qg+Q==",
+			"dependencies": {
+				"@aws-amplify/platform-core": "^1.0.5",
+				"@aws-amplify/plugin-types": "^1.2.2",
+				"@aws-sdk/client-ssm": "^3.624.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-secret/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+			"integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-secret/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-storage": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/backend-storage/-/backend-storage-1.2.1.tgz",
+			"integrity": "sha512-FmGs0rKy2G0El/LNepmOXP8wNNcpU/CmOOBBU+znd85TYONqTH1rpAgNKi1+xYWbNP2Y49YS3xRkWHoouNH/jg==",
+			"dependencies": {
+				"@aws-amplify/backend-output-schemas": "^1.2.1",
+				"@aws-amplify/backend-output-storage": "^1.1.2",
+				"@aws-amplify/plugin-types": "^1.3.0"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-storage/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+			"integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend-storage/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+			"integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/backend/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/client-config": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/client-config/-/client-config-1.4.0.tgz",
+			"integrity": "sha512-Wq8XcydP4OMCUvmzbOv3hEYBIkmt2I2Aybx9yBCXCHYm1X/5dB1Kw6RT0Ci5TtMr1BiWnZpZ6oqEOujFJ4q+WA==",
+			"dependencies": {
+				"@aws-amplify/backend-output-schemas": "^1.2.1",
+				"@aws-amplify/deployed-backend-client": "^1.4.1",
+				"@aws-amplify/model-generator": "^1.0.7",
+				"@aws-amplify/platform-core": "^1.0.7",
+				"@aws-amplify/plugin-types": "^1.2.2",
+				"zod": "^3.22.2"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-amplify": "^3.624.0",
+				"@aws-sdk/client-cloudformation": "^3.624.0",
+				"@aws-sdk/client-s3": "^3.624.0"
+			}
+		},
+		"node_modules/@aws-amplify/client-config/node_modules/@aws-amplify/deployed-backend-client": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/deployed-backend-client/-/deployed-backend-client-1.4.1.tgz",
+			"integrity": "sha512-uvHaYR4HUGNLXvPMrgJbUlse5DEGFXoqJNxJYKn4FNKoSa8F0S5atSUqUpjKHFUp2Xu9VTXViPhqRDNUiRG8EA==",
+			"dependencies": {
+				"@aws-amplify/backend-output-schemas": "^1.2.0",
+				"@aws-amplify/platform-core": "^1.0.5",
+				"@aws-amplify/plugin-types": "^1.2.2",
+				"zod": "^3.22.2"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-amplify": "^3.624.0",
+				"@aws-sdk/client-cloudformation": "^3.624.0",
+				"@aws-sdk/client-s3": "^3.624.0",
+				"@aws-sdk/types": "^3.609.0"
+			}
+		},
+		"node_modules/@aws-amplify/client-config/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+			"integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/client-config/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.10.2.tgz",
+			"integrity": "sha512-SSGchCiyE5GvxuxjCM3CGSmidX6ZggjsBIPWrVSIpXq3oeH2Pci8sPPNGKDogofKt9IEao+iAhg9KQd9+8+MXQ==",
+			"bundleDependencies": [
+				"@aws-amplify/backend-output-schemas",
+				"@aws-amplify/backend-output-storage",
+				"@aws-amplify/graphql-auth-transformer",
+				"@aws-amplify/graphql-conversation-transformer",
+				"@aws-amplify/graphql-default-value-transformer",
+				"@aws-amplify/graphql-directives",
+				"@aws-amplify/graphql-function-transformer",
+				"@aws-amplify/graphql-http-transformer",
+				"@aws-amplify/graphql-index-transformer",
+				"@aws-amplify/graphql-maps-to-transformer",
+				"@aws-amplify/graphql-model-transformer",
+				"@aws-amplify/graphql-predictions-transformer",
+				"@aws-amplify/graphql-relational-transformer",
+				"@aws-amplify/graphql-searchable-transformer",
+				"@aws-amplify/graphql-sql-transformer",
+				"@aws-amplify/graphql-generation-transformer",
+				"@aws-amplify/ai-constructs",
+				"@aws-amplify/graphql-transformer",
+				"@aws-amplify/graphql-transformer-core",
+				"@aws-amplify/graphql-transformer-interfaces",
+				"@aws-amplify/platform-core",
+				"@aws-amplify/plugin-types",
+				"@aws-sdk/client-bedrock-runtime",
+				"@smithy/eventstream-serde-browser",
+				"@smithy/eventstream-serde-config-resolver",
+				"@smithy/eventstream-serde-node",
+				"@smithy/eventstream-serde-universal",
+				"@smithy/eventstream-codec",
+				"@aws-crypto/crc32",
+				"charenc",
+				"crypt",
+				"fs-extra",
+				"graceful-fs",
+				"graphql",
+				"graphql-mapping-template",
+				"graphql-transformer-common",
+				"hjson",
+				"immer",
+				"is-buffer",
+				"jsonfile",
+				"libphonenumber-js",
+				"lodash",
+				"md5",
+				"object-hash",
+				"pluralize",
+				"ts-dedent",
+				"universalify",
+				"zod",
+				"@aws-sdk/client-sts",
+				"is-ci",
+				"lodash.mergewith",
+				"uuid",
+				"@aws-crypto/sha256-browser",
+				"@aws-crypto/sha256-js",
+				"@aws-sdk/client-sso-oidc",
+				"@aws-sdk/core",
+				"@aws-sdk/credential-provider-node",
+				"@aws-sdk/middleware-host-header",
+				"@aws-sdk/middleware-logger",
+				"@aws-sdk/middleware-recursion-detection",
+				"@aws-sdk/middleware-user-agent",
+				"@aws-sdk/region-config-resolver",
+				"@aws-sdk/types",
+				"@aws-sdk/util-endpoints",
+				"@aws-sdk/util-user-agent-browser",
+				"@aws-sdk/util-user-agent-node",
+				"@smithy/config-resolver",
+				"@smithy/core",
+				"@smithy/fetch-http-handler",
+				"@smithy/hash-node",
+				"@smithy/invalid-dependency",
+				"@smithy/middleware-content-length",
+				"@smithy/middleware-endpoint",
+				"@smithy/middleware-retry",
+				"@smithy/middleware-serde",
+				"@smithy/middleware-stack",
+				"@smithy/node-config-provider",
+				"@smithy/node-http-handler",
+				"@smithy/protocol-http",
+				"@smithy/smithy-client",
+				"@smithy/types",
+				"@smithy/url-parser",
+				"@smithy/util-base64",
+				"@smithy/util-body-length-browser",
+				"@smithy/util-body-length-node",
+				"@smithy/util-defaults-mode-browser",
+				"@smithy/util-defaults-mode-node",
+				"@smithy/util-endpoints",
+				"@smithy/util-middleware",
+				"@smithy/util-retry",
+				"@smithy/util-utf8",
+				"tslib",
+				"ci-info",
+				"@aws-crypto/supports-web-crypto",
+				"@aws-crypto/util",
+				"@aws-sdk/util-locate-window",
+				"@smithy/signature-v4",
+				"fast-xml-parser",
+				"@aws-sdk/credential-provider-env",
+				"@aws-sdk/credential-provider-http",
+				"@aws-sdk/credential-provider-ini",
+				"@aws-sdk/credential-provider-process",
+				"@aws-sdk/credential-provider-sso",
+				"@aws-sdk/credential-provider-web-identity",
+				"@smithy/credential-provider-imds",
+				"@smithy/property-provider",
+				"@smithy/shared-ini-file-loader",
+				"@smithy/util-config-provider",
+				"bowser",
+				"@smithy/querystring-builder",
+				"@smithy/util-buffer-from",
+				"@smithy/service-error-classification",
+				"@smithy/abort-controller",
+				"@smithy/util-stream",
+				"@smithy/querystring-parser",
+				"@smithy/is-array-buffer",
+				"@smithy/util-hex-encoding",
+				"@smithy/util-uri-escape",
+				"strnum",
+				"@aws-sdk/token-providers",
+				"@aws-sdk/client-sso",
+				"semver"
+			],
+			"dependencies": {
+				"@aws-amplify/ai-constructs": "^0.1.4",
+				"@aws-amplify/backend-output-schemas": "^1.0.0",
+				"@aws-amplify/backend-output-storage": "^1.0.0",
+				"@aws-amplify/graphql-api-construct": "1.14.0",
+				"@aws-amplify/graphql-auth-transformer": "4.1.2",
+				"@aws-amplify/graphql-conversation-transformer": "0.2.2",
+				"@aws-amplify/graphql-default-value-transformer": "3.0.4",
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-function-transformer": "3.1.1",
+				"@aws-amplify/graphql-generation-transformer": "0.2.2",
+				"@aws-amplify/graphql-http-transformer": "3.0.4",
+				"@aws-amplify/graphql-index-transformer": "3.0.4",
+				"@aws-amplify/graphql-maps-to-transformer": "4.0.4",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-predictions-transformer": "3.0.4",
+				"@aws-amplify/graphql-relational-transformer": "3.0.4",
+				"@aws-amplify/graphql-searchable-transformer": "3.0.4",
+				"@aws-amplify/graphql-sql-transformer": "0.4.4",
+				"@aws-amplify/graphql-transformer": "2.1.2",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"@aws-amplify/platform-core": "^1.0.0",
+				"@aws-amplify/plugin-types": "^1.0.0",
+				"@aws-crypto/crc32": "5.2.0",
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/client-bedrock-runtime": "^3.622.0",
+				"@aws-sdk/client-sso": "3.637.0",
+				"@aws-sdk/client-sso-oidc": "3.637.0",
+				"@aws-sdk/client-sts": "^3.624.0",
+				"@aws-sdk/core": "3.635.0",
+				"@aws-sdk/credential-provider-env": "3.620.1",
+				"@aws-sdk/credential-provider-http": "3.635.0",
+				"@aws-sdk/credential-provider-ini": "3.637.0",
+				"@aws-sdk/credential-provider-node": "3.637.0",
+				"@aws-sdk/credential-provider-process": "3.620.1",
+				"@aws-sdk/credential-provider-sso": "3.637.0",
+				"@aws-sdk/credential-provider-web-identity": "3.621.0",
+				"@aws-sdk/middleware-host-header": "3.620.0",
+				"@aws-sdk/middleware-logger": "3.609.0",
+				"@aws-sdk/middleware-recursion-detection": "3.620.0",
+				"@aws-sdk/middleware-user-agent": "3.637.0",
+				"@aws-sdk/region-config-resolver": "3.614.0",
+				"@aws-sdk/token-providers": "3.614.0",
+				"@aws-sdk/types": "3.609.0",
+				"@aws-sdk/util-endpoints": "3.637.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-user-agent-browser": "3.609.0",
+				"@aws-sdk/util-user-agent-node": "3.614.0",
+				"@smithy/abort-controller": "^3.1.1",
+				"@smithy/config-resolver": "^3.0.5",
+				"@smithy/core": "^2.4.0",
+				"@smithy/credential-provider-imds": "^3.2.0",
+				"@smithy/eventstream-codec": "^3.1.2",
+				"@smithy/eventstream-serde-browser": "^3.0.6",
+				"@smithy/eventstream-serde-config-resolver": "^3.0.3",
+				"@smithy/eventstream-serde-node": "^3.0.5",
+				"@smithy/eventstream-serde-universal": "^3.0.5",
+				"@smithy/fetch-http-handler": "^3.2.4",
+				"@smithy/hash-node": "^3.0.3",
+				"@smithy/invalid-dependency": "^3.0.3",
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/middleware-content-length": "^3.0.5",
+				"@smithy/middleware-endpoint": "^3.1.0",
+				"@smithy/middleware-retry": "^3.0.15",
+				"@smithy/middleware-serde": "^3.0.3",
+				"@smithy/middleware-stack": "^3.0.3",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/node-http-handler": "^3.1.4",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/querystring-builder": "^3.0.3",
+				"@smithy/querystring-parser": "^3.0.3",
+				"@smithy/service-error-classification": "^3.0.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/signature-v4": "^4.1.0",
+				"@smithy/smithy-client": "^3.2.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/url-parser": "^3.0.3",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-buffer-from": "^3.0.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.15",
+				"@smithy/util-defaults-mode-node": "^3.0.15",
+				"@smithy/util-endpoints": "^2.0.5",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.3",
+				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-stream": "^3.1.3",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"bowser": "^2.11.0",
+				"charenc": "^0.0.2",
+				"ci-info": "^3.2.0",
+				"crypt": "^0.0.2",
+				"fast-xml-parser": "4.4.1",
+				"fs-extra": "^8.1.0",
+				"graceful-fs": "^4.2.0",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"hjson": "^3.2.2",
+				"immer": "^9.0.12",
+				"is-buffer": "~1.1.6",
+				"is-ci": "^3.0.1",
+				"jsonfile": "^4.0.0",
+				"libphonenumber-js": "1.9.47",
+				"lodash": "^4.17.21",
+				"lodash.mergewith": "^4.6.2",
+				"md5": "^2.2.1",
+				"object-hash": "^3.0.0",
+				"pluralize": "8.0.0",
+				"semver": "^7.6.3",
+				"strnum": "^1.0.5",
+				"ts-dedent": "^2.0.0",
+				"tslib": "^2.6.2",
+				"universalify": "^0.1.0",
+				"uuid": "^9.0.1",
+				"zod": "^3.22.2"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs": {
+			"version": "0.1.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/plugin-types": "^1.0.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.622.0",
+				"@smithy/types": "^3.3.0"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-schemas": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"zod": "^3.22.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-storage": {
+			"version": "1.1.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/backend-output-schemas": "^1.2.0",
+				"@aws-amplify/platform-core": "^1.0.6"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
+			"version": "4.1.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-relational-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"lodash": "^4.17.21",
+				"md5": "^2.3.0"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-conversation-transformer": {
+			"version": "0.2.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/ai-constructs": "^0.1.4",
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-index-transformer": "3.0.4",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-relational-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"immer": "^9.0.12"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"libphonenumber-js": "1.9.47"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-directives": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+			"inBundle": true,
+			"license": "Apache-2.0"
 		},
-		"node_modules/@aws-amplify/analytics/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-function-transformer": {
+			"version": "3.1.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-amplify/analytics/node_modules/@smithy/util-utf8": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-			"integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.0.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-amplify/api": {
-			"version": "6.0.51",
-			"resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.51.tgz",
-			"integrity": "sha512-p5jWW6saazLuJ+8TkXLB8O7ZGXMCuP9HArIt9o0jP+nDRBIqsRb5IQQb14DDQ8PkBfleKjKHeI69c246uTsKSA==",
-			"dependencies": {
-				"@aws-amplify/api-graphql": "4.3.2",
-				"@aws-amplify/api-rest": "4.0.49",
-				"tslib": "^2.5.0"
-			}
-		},
-		"node_modules/@aws-amplify/api-graphql": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.3.2.tgz",
-			"integrity": "sha512-izdaQOUMD/CuTY7eHI2ngjt2i80bMynNT63HueJszkeyc+N/eEl5qAQNRHx+VaVGiyGgiz82WxcEU6gfLKnvMA==",
-			"dependencies": {
-				"@aws-amplify/api-rest": "4.0.49",
-				"@aws-amplify/core": "6.4.2",
-				"@aws-amplify/data-schema": "^1.5.0",
-				"@aws-sdk/types": "3.387.0",
-				"graphql": "15.8.0",
-				"rxjs": "^7.8.1",
-				"tslib": "^2.5.0",
-				"uuid": "^9.0.0"
-			}
-		},
-		"node_modules/@aws-amplify/api-graphql/node_modules/@aws-sdk/types": {
-			"version": "3.387.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.387.0.tgz",
-			"integrity": "sha512-YTjFabNwjTF+6yl88f0/tWff018qmmgMmjlw45s6sdVKueWxdxV68U7gepNLF2nhaQPZa6FDOBoA51NaviVs0Q==",
-			"dependencies": {
-				"@smithy/types": "^2.1.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-amplify/api-graphql/node_modules/@smithy/types": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-			"integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-amplify/api-rest": {
-			"version": "4.0.49",
-			"resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.49.tgz",
-			"integrity": "sha512-o2C/62yAvn/KvKDkvHUtMEroT6aG0YAEgjSWjkerURipHx0o5JvQVcTuKAvop7ZxnzV/RO+8qdSg/iI14kzZnw==",
-			"dependencies": {
-				"tslib": "^2.5.0"
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
 			},
 			"peerDependencies": {
-				"@aws-amplify/core": "^6.1.0"
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
 			}
 		},
-		"node_modules/@aws-amplify/auth": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.4.2.tgz",
-			"integrity": "sha512-Mfx5AW5RgM0qE9DuJNlFAl4yzFAN1nSxCuLvGrWpKUrcYDomy5I2zzETCxRcJvrb94qzg3aPHlooR8Lgl6t6qg==",
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-generation-transformer": {
+			"version": "0.2.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"tslib": "^2.5.0"
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"immer": "^9.0.12"
 			},
 			"peerDependencies": {
-				"@aws-amplify/core": "^6.1.0"
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
 			}
 		},
-		"node_modules/@aws-amplify/core": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.4.2.tgz",
-			"integrity": "sha512-kumvcxy8dk+L78MBjzfCrd+iVefliTvrbYskNFFbxbKCxUB7QavgALrVi31VXQxBW5YvImjAsS1qS7SY1YkYHQ==",
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-http-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/types": "3.398.0",
-				"@smithy/util-hex-encoding": "2.0.0",
-				"@types/uuid": "^9.0.0",
-				"js-cookie": "^3.0.5",
-				"rxjs": "^7.8.1",
-				"tslib": "^2.5.0",
-				"uuid": "^9.0.0"
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
 			}
 		},
-		"node_modules/@aws-amplify/core/node_modules/@aws-crypto/sha256-js": {
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-index-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
+			"version": "4.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-model-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-index-transformer": "3.0.4",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"immer": "^9.0.12"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
+			"version": "0.4.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer": {
+			"version": "2.1.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-auth-transformer": "4.1.2",
+				"@aws-amplify/graphql-conversation-transformer": "0.2.2",
+				"@aws-amplify/graphql-default-value-transformer": "3.0.4",
+				"@aws-amplify/graphql-function-transformer": "3.1.1",
+				"@aws-amplify/graphql-generation-transformer": "0.2.2",
+				"@aws-amplify/graphql-http-transformer": "3.0.4",
+				"@aws-amplify/graphql-index-transformer": "3.0.4",
+				"@aws-amplify/graphql-maps-to-transformer": "4.0.4",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-predictions-transformer": "3.0.4",
+				"@aws-amplify/graphql-relational-transformer": "3.0.4",
+				"@aws-amplify/graphql-searchable-transformer": "3.0.4",
+				"@aws-amplify/graphql-sql-transformer": "0.4.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-core": {
+			"version": "3.1.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"fs-extra": "^8.1.0",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"hjson": "^3.2.2",
+				"lodash": "^4.17.21",
+				"md5": "^2.3.0",
+				"object-hash": "^3.0.0",
+				"ts-dedent": "^2.0.0"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
+			"version": "4.1.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"graphql": "^15.5.0"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/plugin-types": "^1.2.1",
+				"@aws-sdk/client-sts": "^3.624.0",
+				"is-ci": "^3.0.1",
+				"lodash.mergewith": "^4.6.2",
+				"semver": "^7.6.3",
+				"uuid": "^9.0.1",
+				"zod": "^3.22.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.2.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/crc32": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/util": "^5.2.0",
 				"@aws-sdk/types": "^3.222.0",
@@ -203,32 +1330,48 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-amplify/core/node_modules/@aws-crypto/util": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
 				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
 				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-amplify/core/node_modules/@aws-sdk/types": {
-			"version": "3.398.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.398.0.tgz",
-			"integrity": "sha512-r44fkS+vsEgKCuEuTV+TIk0t0m5ZlXHNjSDYEUvzLStbbfUFiNus/YG4UCa0wOk9R7VuQI67badsvvPeVPCGDQ==",
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^2.2.2",
-				"tslib": "^2.5.0"
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-amplify/core/node_modules/@smithy/is-array-buffer": {
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -236,21 +1379,10 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-amplify/core/node_modules/@smithy/types": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-			"integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-amplify/core/node_modules/@smithy/util-buffer-from": {
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^2.2.0",
 				"tslib": "^2.6.2"
@@ -259,27 +1391,2226 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-amplify/core/node_modules/@smithy/util-hex-encoding": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-			"integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-			"dependencies": {
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-amplify/core/node_modules/@smithy/util-utf8": {
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
 			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/util-buffer-from": "^2.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.651.1",
+				"@aws-sdk/client-sts": "3.651.1",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/credential-provider-node": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/eventstream-serde-browser": "^3.0.7",
+				"@smithy/eventstream-serde-config-resolver": "^3.0.4",
+				"@smithy/eventstream-serde-node": "^3.0.6",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-stream": "^3.1.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/credential-provider-node": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.651.1"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/core": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^2.4.1",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/signature-v4": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-stream": "^3.1.4",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.649.0",
+				"@aws-sdk/credential-provider-http": "3.649.0",
+				"@aws-sdk/credential-provider-process": "3.649.0",
+				"@aws-sdk/credential-provider-sso": "3.651.1",
+				"@aws-sdk/credential-provider-web-identity": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/credential-provider-imds": "^3.2.1",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.651.1"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.649.0",
+				"@aws-sdk/credential-provider-http": "3.649.0",
+				"@aws-sdk/credential-provider-ini": "3.651.1",
+				"@aws-sdk/credential-provider-process": "3.649.0",
+				"@aws-sdk/credential-provider-sso": "3.651.1",
+				"@aws-sdk/credential-provider-web-identity": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/credential-provider-imds": "^3.2.1",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.651.1",
+				"@aws-sdk/token-providers": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.649.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sso-oidc": "^3.649.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-endpoints": "^2.1.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sso": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.635.0",
+				"@aws-sdk/middleware-host-header": "3.620.0",
+				"@aws-sdk/middleware-logger": "3.609.0",
+				"@aws-sdk/middleware-recursion-detection": "3.620.0",
+				"@aws-sdk/middleware-user-agent": "3.637.0",
+				"@aws-sdk/region-config-resolver": "3.614.0",
+				"@aws-sdk/types": "3.609.0",
+				"@aws-sdk/util-endpoints": "3.637.0",
+				"@aws-sdk/util-user-agent-browser": "3.609.0",
+				"@aws-sdk/util-user-agent-node": "3.614.0",
+				"@smithy/config-resolver": "^3.0.5",
+				"@smithy/core": "^2.4.0",
+				"@smithy/fetch-http-handler": "^3.2.4",
+				"@smithy/hash-node": "^3.0.3",
+				"@smithy/invalid-dependency": "^3.0.3",
+				"@smithy/middleware-content-length": "^3.0.5",
+				"@smithy/middleware-endpoint": "^3.1.0",
+				"@smithy/middleware-retry": "^3.0.15",
+				"@smithy/middleware-serde": "^3.0.3",
+				"@smithy/middleware-stack": "^3.0.3",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/node-http-handler": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/smithy-client": "^3.2.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/url-parser": "^3.0.3",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.15",
+				"@smithy/util-defaults-mode-node": "^3.0.15",
+				"@smithy/util-endpoints": "^2.0.5",
+				"@smithy/util-middleware": "^3.0.3",
+				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.635.0",
+				"@aws-sdk/credential-provider-node": "3.637.0",
+				"@aws-sdk/middleware-host-header": "3.620.0",
+				"@aws-sdk/middleware-logger": "3.609.0",
+				"@aws-sdk/middleware-recursion-detection": "3.620.0",
+				"@aws-sdk/middleware-user-agent": "3.637.0",
+				"@aws-sdk/region-config-resolver": "3.614.0",
+				"@aws-sdk/types": "3.609.0",
+				"@aws-sdk/util-endpoints": "3.637.0",
+				"@aws-sdk/util-user-agent-browser": "3.609.0",
+				"@aws-sdk/util-user-agent-node": "3.614.0",
+				"@smithy/config-resolver": "^3.0.5",
+				"@smithy/core": "^2.4.0",
+				"@smithy/fetch-http-handler": "^3.2.4",
+				"@smithy/hash-node": "^3.0.3",
+				"@smithy/invalid-dependency": "^3.0.3",
+				"@smithy/middleware-content-length": "^3.0.5",
+				"@smithy/middleware-endpoint": "^3.1.0",
+				"@smithy/middleware-retry": "^3.0.15",
+				"@smithy/middleware-serde": "^3.0.3",
+				"@smithy/middleware-stack": "^3.0.3",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/node-http-handler": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/smithy-client": "^3.2.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/url-parser": "^3.0.3",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.15",
+				"@smithy/util-defaults-mode-node": "^3.0.15",
+				"@smithy/util-endpoints": "^2.0.5",
+				"@smithy/util-middleware": "^3.0.3",
+				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.637.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.651.1",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/credential-provider-node": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/credential-provider-node": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.651.1"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/core": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^2.4.1",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/signature-v4": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-stream": "^3.1.4",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.649.0",
+				"@aws-sdk/credential-provider-http": "3.649.0",
+				"@aws-sdk/credential-provider-process": "3.649.0",
+				"@aws-sdk/credential-provider-sso": "3.651.1",
+				"@aws-sdk/credential-provider-web-identity": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/credential-provider-imds": "^3.2.1",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.651.1"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.649.0",
+				"@aws-sdk/credential-provider-http": "3.649.0",
+				"@aws-sdk/credential-provider-ini": "3.651.1",
+				"@aws-sdk/credential-provider-process": "3.649.0",
+				"@aws-sdk/credential-provider-sso": "3.651.1",
+				"@aws-sdk/credential-provider-web-identity": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/credential-provider-imds": "^3.2.1",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.651.1",
+				"@aws-sdk/token-providers": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.649.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sso-oidc": "^3.649.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-endpoints": "^2.1.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/core": {
+			"version": "3.635.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^2.4.0",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/signature-v4": "^4.1.0",
+				"@smithy/smithy-client": "^3.2.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/util-middleware": "^3.0.3",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.620.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.635.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/fetch-http-handler": "^3.2.4",
+				"@smithy/node-http-handler": "^3.1.4",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/smithy-client": "^3.2.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/util-stream": "^3.1.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.620.1",
+				"@aws-sdk/credential-provider-http": "3.635.0",
+				"@aws-sdk/credential-provider-process": "3.620.1",
+				"@aws-sdk/credential-provider-sso": "3.637.0",
+				"@aws-sdk/credential-provider-web-identity": "3.621.0",
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/credential-provider-imds": "^3.2.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.637.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.620.1",
+				"@aws-sdk/credential-provider-http": "3.635.0",
+				"@aws-sdk/credential-provider-ini": "3.637.0",
+				"@aws-sdk/credential-provider-process": "3.620.1",
+				"@aws-sdk/credential-provider-sso": "3.637.0",
+				"@aws-sdk/credential-provider-web-identity": "3.621.0",
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/credential-provider-imds": "^3.2.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.620.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.637.0",
+				"@aws-sdk/token-providers": "3.614.0",
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.621.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.621.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.620.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.609.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.620.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@aws-sdk/util-endpoints": "3.637.0",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.614.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/token-providers": {
+			"version": "3.614.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sso-oidc": "^3.614.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/types": {
+			"version": "3.609.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/util-endpoints": "^2.0.5",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.568.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.609.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/types": "^3.3.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.614.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/abort-controller": {
+			"version": "3.1.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/config-resolver": {
+			"version": "3.0.8",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.6",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/core": {
+			"version": "2.4.3",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/middleware-endpoint": "^3.1.3",
+				"@smithy/middleware-retry": "^3.0.18",
+				"@smithy/middleware-serde": "^3.0.6",
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/smithy-client": "^3.3.2",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.6",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/credential-provider-imds": {
+			"version": "3.2.3",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/property-provider": "^3.1.6",
+				"@smithy/types": "^3.4.2",
+				"@smithy/url-parser": "^3.0.6",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-codec": {
+			"version": "3.1.5",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-browser": {
+			"version": "3.0.9",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^3.0.8",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-config-resolver": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-node": {
+			"version": "3.0.8",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^3.0.8",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-universal": {
+			"version": "3.0.8",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/eventstream-codec": "^3.1.5",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/fetch-http-handler": {
+			"version": "3.2.7",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/querystring-builder": "^3.0.6",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-base64": "^3.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/hash-node": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-buffer-from": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/invalid-dependency": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/is-array-buffer": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-content-length": {
+			"version": "3.0.8",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-endpoint": {
+			"version": "3.1.3",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/middleware-serde": "^3.0.6",
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.7",
+				"@smithy/types": "^3.4.2",
+				"@smithy/url-parser": "^3.0.6",
+				"@smithy/util-middleware": "^3.0.6",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-retry": {
+			"version": "3.0.18",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/service-error-classification": "^3.0.6",
+				"@smithy/smithy-client": "^3.3.2",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-middleware": "^3.0.6",
+				"@smithy/util-retry": "^3.0.6",
+				"tslib": "^2.6.2",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-serde": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-stack": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/node-config-provider": {
+			"version": "3.1.7",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/property-provider": "^3.1.6",
+				"@smithy/shared-ini-file-loader": "^3.1.7",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/node-http-handler": {
+			"version": "3.2.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/abort-controller": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/querystring-builder": "^3.0.6",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/property-provider": {
+			"version": "3.1.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/protocol-http": {
+			"version": "4.1.3",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/querystring-builder": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/querystring-parser": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/service-error-classification": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/shared-ini-file-loader": {
+			"version": "3.1.7",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/signature-v4": {
+			"version": "4.1.3",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.6",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/smithy-client": {
+			"version": "3.3.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/middleware-endpoint": "^3.1.3",
+				"@smithy/middleware-stack": "^3.0.6",
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-stream": "^3.1.6",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/types": {
+			"version": "3.4.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/url-parser": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/querystring-parser": "^3.0.6",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-base64": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-body-length-browser": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-body-length-node": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-buffer-from": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-config-provider": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "3.0.18",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/property-provider": "^3.1.6",
+				"@smithy/smithy-client": "^3.3.2",
+				"@smithy/types": "^3.4.2",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-defaults-mode-node": {
+			"version": "3.0.18",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/config-resolver": "^3.0.8",
+				"@smithy/credential-provider-imds": "^3.2.3",
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/property-provider": "^3.1.6",
+				"@smithy/smithy-client": "^3.3.2",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-endpoints": {
+			"version": "2.1.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-hex-encoding": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-middleware": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-retry": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/service-error-classification": "^3.0.6",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-stream": {
+			"version": "3.1.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/fetch-http-handler": "^3.2.7",
+				"@smithy/node-http-handler": "^3.2.2",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-buffer-from": "^3.0.0",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-uri-escape": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-utf8": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/bowser": {
+			"version": "2.11.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/charenc": {
+			"version": "0.0.2",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/ci-info": {
+			"version": "3.9.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/crypt": {
+			"version": "0.0.2",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/fast-xml-parser": {
+			"version": "4.4.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
+				}
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/graphql": {
+			"version": "15.9.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.x"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/graphql-mapping-template": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/graphql-transformer-common": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"md5": "^2.2.1",
+				"pluralize": "8.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/hjson": {
+			"version": "3.2.2",
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"hjson": "bin/hjson"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/immer": {
+			"version": "9.0.21",
+			"inBundle": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/is-buffer": {
+			"version": "1.1.6",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/is-ci": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ci-info": "^3.2.0"
+			},
+			"bin": {
+				"is-ci": "bin.js"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/jsonfile": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/libphonenumber-js": {
+			"version": "1.9.47",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/lodash": {
+			"version": "4.17.21",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/lodash.mergewith": {
+			"version": "4.6.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/md5": {
+			"version": "2.3.0",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/object-hash": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/pluralize": {
+			"version": "8.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/semver": {
+			"version": "7.6.3",
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/strnum": {
+			"version": "1.0.5",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/ts-dedent": {
+			"version": "2.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.10"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/tslib": {
+			"version": "2.7.0",
+			"inBundle": true,
+			"license": "0BSD"
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/universalify": {
+			"version": "0.1.2",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/uuid": {
+			"version": "9.0.1",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@aws-amplify/data-construct/node_modules/zod": {
+			"version": "3.23.8",
+			"inBundle": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@aws-amplify/data-schema": {
@@ -303,80 +3634,674 @@
 				"rxjs": "^7.8.1"
 			}
 		},
-		"node_modules/@aws-amplify/datastore": {
-			"version": "5.0.51",
-			"resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.51.tgz",
-			"integrity": "sha512-R4XAsmrT7psWnvgc6lr8hxbJwFd6iHgsiqazOH67h9tusgmIFAp+HEgKPV/sUrkT2aIEy8Ge7so5y1Tku70zBA==",
+		"node_modules/@aws-amplify/graphql-api-construct": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.14.0.tgz",
+			"integrity": "sha512-u4lwTW/4+9+AVe9nrg5Ob9qdTyIwwSbOiSBy5OQPdVHRJ/tPdpfeP+JJpG1dcTiBmCydlJocOQJEBdDAoCBjqQ==",
+			"bundleDependencies": [
+				"@aws-amplify/backend-output-schemas",
+				"@aws-amplify/backend-output-storage",
+				"@aws-amplify/graphql-auth-transformer",
+				"@aws-amplify/graphql-conversation-transformer",
+				"@aws-amplify/graphql-default-value-transformer",
+				"@aws-amplify/graphql-directives",
+				"@aws-amplify/graphql-function-transformer",
+				"@aws-amplify/graphql-generation-transformer",
+				"@aws-amplify/graphql-http-transformer",
+				"@aws-amplify/graphql-index-transformer",
+				"@aws-amplify/graphql-maps-to-transformer",
+				"@aws-amplify/graphql-model-transformer",
+				"@aws-amplify/graphql-predictions-transformer",
+				"@aws-amplify/graphql-relational-transformer",
+				"@aws-amplify/graphql-searchable-transformer",
+				"@aws-amplify/graphql-sql-transformer",
+				"@aws-amplify/graphql-transformer",
+				"@aws-amplify/graphql-transformer-core",
+				"@aws-amplify/graphql-transformer-interfaces",
+				"@aws-amplify/platform-core",
+				"@aws-amplify/plugin-types",
+				"@aws-amplify/ai-constructs",
+				"@aws-sdk/client-bedrock-runtime",
+				"@smithy/eventstream-serde-browser",
+				"@smithy/eventstream-serde-config-resolver",
+				"@smithy/eventstream-serde-node",
+				"@smithy/eventstream-serde-universal",
+				"@smithy/eventstream-codec",
+				"@aws-crypto/crc32",
+				"charenc",
+				"crypt",
+				"fs-extra",
+				"graceful-fs",
+				"graphql",
+				"graphql-mapping-template",
+				"graphql-transformer-common",
+				"hjson",
+				"immer",
+				"is-buffer",
+				"jsonfile",
+				"libphonenumber-js",
+				"lodash",
+				"md5",
+				"object-hash",
+				"pluralize",
+				"ts-dedent",
+				"universalify",
+				"zod",
+				"@aws-sdk/client-sts",
+				"is-ci",
+				"lodash.mergewith",
+				"uuid",
+				"@aws-crypto/sha256-browser",
+				"@aws-crypto/sha256-js",
+				"@aws-sdk/client-sso-oidc",
+				"@aws-sdk/core",
+				"@aws-sdk/credential-provider-node",
+				"@aws-sdk/middleware-host-header",
+				"@aws-sdk/middleware-logger",
+				"@aws-sdk/middleware-recursion-detection",
+				"@aws-sdk/middleware-user-agent",
+				"@aws-sdk/region-config-resolver",
+				"@aws-sdk/types",
+				"@aws-sdk/util-endpoints",
+				"@aws-sdk/util-user-agent-browser",
+				"@aws-sdk/util-user-agent-node",
+				"@smithy/config-resolver",
+				"@smithy/core",
+				"@smithy/fetch-http-handler",
+				"@smithy/hash-node",
+				"@smithy/invalid-dependency",
+				"@smithy/middleware-content-length",
+				"@smithy/middleware-endpoint",
+				"@smithy/middleware-retry",
+				"@smithy/middleware-serde",
+				"@smithy/middleware-stack",
+				"@smithy/node-config-provider",
+				"@smithy/node-http-handler",
+				"@smithy/protocol-http",
+				"@smithy/smithy-client",
+				"@smithy/types",
+				"@smithy/url-parser",
+				"@smithy/util-base64",
+				"@smithy/util-body-length-browser",
+				"@smithy/util-body-length-node",
+				"@smithy/util-defaults-mode-browser",
+				"@smithy/util-defaults-mode-node",
+				"@smithy/util-endpoints",
+				"@smithy/util-middleware",
+				"@smithy/util-retry",
+				"@smithy/util-utf8",
+				"tslib",
+				"ci-info",
+				"@aws-crypto/supports-web-crypto",
+				"@aws-crypto/util",
+				"@aws-sdk/util-locate-window",
+				"@smithy/signature-v4",
+				"fast-xml-parser",
+				"@aws-sdk/credential-provider-env",
+				"@aws-sdk/credential-provider-http",
+				"@aws-sdk/credential-provider-ini",
+				"@aws-sdk/credential-provider-process",
+				"@aws-sdk/credential-provider-sso",
+				"@aws-sdk/credential-provider-web-identity",
+				"@smithy/credential-provider-imds",
+				"@smithy/property-provider",
+				"@smithy/shared-ini-file-loader",
+				"@smithy/util-config-provider",
+				"bowser",
+				"@smithy/querystring-builder",
+				"@smithy/util-buffer-from",
+				"@smithy/service-error-classification",
+				"@smithy/abort-controller",
+				"@smithy/util-stream",
+				"@smithy/querystring-parser",
+				"@smithy/is-array-buffer",
+				"@smithy/util-hex-encoding",
+				"@smithy/util-uri-escape",
+				"strnum",
+				"@aws-sdk/token-providers",
+				"@aws-sdk/client-sso",
+				"semver"
+			],
 			"dependencies": {
-				"@aws-amplify/api": "6.0.51",
-				"buffer": "4.9.2",
-				"idb": "5.0.6",
-				"immer": "9.0.6",
-				"rxjs": "^7.8.1",
-				"ulid": "^2.3.0"
-			},
-			"peerDependencies": {
-				"@aws-amplify/core": "^6.1.0"
-			}
-		},
-		"node_modules/@aws-amplify/datastore/node_modules/buffer": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-			"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-			"dependencies": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
-			}
-		},
-		"node_modules/@aws-amplify/datastore/node_modules/idb": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/idb/-/idb-5.0.6.tgz",
-			"integrity": "sha512-/PFvOWPzRcEPmlDt5jEvzVZVs0wyd/EvGvkDIcbBpGuMMLQKrTPG0TxvE2UJtgZtCQCmOtM2QD7yQJBVEjKGOw=="
-		},
-		"node_modules/@aws-amplify/notifications": {
-			"version": "2.0.49",
-			"resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.49.tgz",
-			"integrity": "sha512-26+vgiCnugF3wGyVPzOFsc0BFC/nGf+70LpzsYrxLes4OaLq1cBVJgh7q6p9nT+qjsrmlVGwl0kU49OIyPx7xg==",
-			"dependencies": {
+				"@aws-amplify/ai-constructs": "^0.1.4",
+				"@aws-amplify/backend-output-schemas": "^1.0.0",
+				"@aws-amplify/backend-output-storage": "^1.0.0",
+				"@aws-amplify/graphql-auth-transformer": "4.1.2",
+				"@aws-amplify/graphql-conversation-transformer": "0.2.2",
+				"@aws-amplify/graphql-default-value-transformer": "3.0.4",
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-function-transformer": "3.1.1",
+				"@aws-amplify/graphql-generation-transformer": "0.2.2",
+				"@aws-amplify/graphql-http-transformer": "3.0.4",
+				"@aws-amplify/graphql-index-transformer": "3.0.4",
+				"@aws-amplify/graphql-maps-to-transformer": "4.0.4",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-predictions-transformer": "3.0.4",
+				"@aws-amplify/graphql-relational-transformer": "3.0.4",
+				"@aws-amplify/graphql-searchable-transformer": "3.0.4",
+				"@aws-amplify/graphql-sql-transformer": "0.4.4",
+				"@aws-amplify/graphql-transformer": "2.1.2",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"@aws-amplify/platform-core": "^1.0.0",
+				"@aws-amplify/plugin-types": "^1.0.0",
+				"@aws-crypto/crc32": "5.2.0",
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/client-bedrock-runtime": "^3.622.0",
+				"@aws-sdk/client-sso": "3.637.0",
+				"@aws-sdk/client-sso-oidc": "3.637.0",
+				"@aws-sdk/client-sts": "^3.624.0",
+				"@aws-sdk/core": "3.635.0",
+				"@aws-sdk/credential-provider-env": "3.620.1",
+				"@aws-sdk/credential-provider-http": "3.635.0",
+				"@aws-sdk/credential-provider-ini": "3.637.0",
+				"@aws-sdk/credential-provider-node": "3.637.0",
+				"@aws-sdk/credential-provider-process": "3.620.1",
+				"@aws-sdk/credential-provider-sso": "3.637.0",
+				"@aws-sdk/credential-provider-web-identity": "3.621.0",
+				"@aws-sdk/middleware-host-header": "3.620.0",
+				"@aws-sdk/middleware-logger": "3.609.0",
+				"@aws-sdk/middleware-recursion-detection": "3.620.0",
+				"@aws-sdk/middleware-user-agent": "3.637.0",
+				"@aws-sdk/region-config-resolver": "3.614.0",
+				"@aws-sdk/token-providers": "3.614.0",
+				"@aws-sdk/types": "3.609.0",
+				"@aws-sdk/util-endpoints": "3.637.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-user-agent-browser": "3.609.0",
+				"@aws-sdk/util-user-agent-node": "3.614.0",
+				"@smithy/abort-controller": "^3.1.1",
+				"@smithy/config-resolver": "^3.0.5",
+				"@smithy/core": "^2.4.0",
+				"@smithy/credential-provider-imds": "^3.2.0",
+				"@smithy/eventstream-codec": "^3.1.2",
+				"@smithy/eventstream-serde-browser": "^3.0.6",
+				"@smithy/eventstream-serde-config-resolver": "^3.0.3",
+				"@smithy/eventstream-serde-node": "^3.0.5",
+				"@smithy/eventstream-serde-universal": "^3.0.5",
+				"@smithy/fetch-http-handler": "^3.2.4",
+				"@smithy/hash-node": "^3.0.3",
+				"@smithy/invalid-dependency": "^3.0.3",
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/middleware-content-length": "^3.0.5",
+				"@smithy/middleware-endpoint": "^3.1.0",
+				"@smithy/middleware-retry": "^3.0.15",
+				"@smithy/middleware-serde": "^3.0.3",
+				"@smithy/middleware-stack": "^3.0.3",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/node-http-handler": "^3.1.4",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/querystring-builder": "^3.0.3",
+				"@smithy/querystring-parser": "^3.0.3",
+				"@smithy/service-error-classification": "^3.0.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/signature-v4": "^4.1.0",
+				"@smithy/smithy-client": "^3.2.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/url-parser": "^3.0.3",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-buffer-from": "^3.0.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.15",
+				"@smithy/util-defaults-mode-node": "^3.0.15",
+				"@smithy/util-endpoints": "^2.0.5",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.3",
+				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-stream": "^3.1.3",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"bowser": "^2.11.0",
+				"charenc": "^0.0.2",
+				"ci-info": "^3.2.0",
+				"crypt": "^0.0.2",
+				"fast-xml-parser": "4.4.1",
+				"fs-extra": "^8.1.0",
+				"graceful-fs": "^4.2.0",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"hjson": "^3.2.2",
+				"immer": "^9.0.12",
+				"is-buffer": "~1.1.6",
+				"is-ci": "^3.0.1",
+				"jsonfile": "^4.0.0",
+				"libphonenumber-js": "1.9.47",
 				"lodash": "^4.17.21",
-				"tslib": "^2.5.0"
+				"lodash.mergewith": "^4.6.2",
+				"md5": "^2.2.1",
+				"object-hash": "^3.0.0",
+				"pluralize": "8.0.0",
+				"semver": "^7.6.3",
+				"strnum": "^1.0.5",
+				"ts-dedent": "^2.0.0",
+				"tslib": "^2.6.2",
+				"universalify": "^0.1.0",
+				"uuid": "^9.0.1",
+				"zod": "^3.22.2"
 			},
 			"peerDependencies": {
-				"@aws-amplify/core": "^6.1.0"
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
 			}
 		},
-		"node_modules/@aws-amplify/storage": {
-			"version": "6.6.7",
-			"resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.6.7.tgz",
-			"integrity": "sha512-iTpVvTzAGoAzXpI72SJBez3qwqXH8I1IxRKJOURXkv4z2rBeFfCHYv8z+o2DHv7YQ+ATuuQF1TvmQ1Xsat1PLw==",
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs": {
+			"version": "0.1.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.398.0",
-				"@smithy/md5-js": "2.0.7",
-				"buffer": "4.9.2",
-				"fast-xml-parser": "^4.4.1",
-				"tslib": "^2.5.0"
+				"@aws-amplify/plugin-types": "^1.0.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.622.0",
+				"@smithy/types": "^3.3.0"
 			},
 			"peerDependencies": {
-				"@aws-amplify/core": "^6.1.0"
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
 			}
 		},
-		"node_modules/@aws-amplify/storage/node_modules/@aws-sdk/types": {
-			"version": "3.398.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.398.0.tgz",
-			"integrity": "sha512-r44fkS+vsEgKCuEuTV+TIk0t0m5ZlXHNjSDYEUvzLStbbfUFiNus/YG4UCa0wOk9R7VuQI67badsvvPeVPCGDQ==",
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-schemas": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"zod": "^3.22.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-storage": {
+			"version": "1.1.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^2.2.2",
-				"tslib": "^2.5.0"
+				"@aws-amplify/backend-output-schemas": "^1.2.0",
+				"@aws-amplify/platform-core": "^1.0.6"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
+			"version": "4.1.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-relational-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"lodash": "^4.17.21",
+				"md5": "^2.3.0"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-conversation-transformer": {
+			"version": "0.2.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/ai-constructs": "^0.1.4",
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-index-transformer": "3.0.4",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-relational-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"immer": "^9.0.12"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"libphonenumber-js": "1.9.47"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-directives": {
+			"version": "2.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-function-transformer": {
+			"version": "3.1.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-generation-transformer": {
+			"version": "0.2.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"immer": "^9.0.12"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-http-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-index-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
+			"version": "4.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-model-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-index-transformer": "3.0.4",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"immer": "^9.0.12"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
+			"version": "0.4.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer": {
+			"version": "2.1.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-auth-transformer": "4.1.2",
+				"@aws-amplify/graphql-conversation-transformer": "0.2.2",
+				"@aws-amplify/graphql-default-value-transformer": "3.0.4",
+				"@aws-amplify/graphql-function-transformer": "3.1.1",
+				"@aws-amplify/graphql-generation-transformer": "0.2.2",
+				"@aws-amplify/graphql-http-transformer": "3.0.4",
+				"@aws-amplify/graphql-index-transformer": "3.0.4",
+				"@aws-amplify/graphql-maps-to-transformer": "4.0.4",
+				"@aws-amplify/graphql-model-transformer": "3.0.4",
+				"@aws-amplify/graphql-predictions-transformer": "3.0.4",
+				"@aws-amplify/graphql-relational-transformer": "3.0.4",
+				"@aws-amplify/graphql-searchable-transformer": "3.0.4",
+				"@aws-amplify/graphql-sql-transformer": "0.4.4",
+				"@aws-amplify/graphql-transformer-core": "3.1.2",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-core": {
+			"version": "3.1.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/graphql-directives": "2.2.0",
+				"@aws-amplify/graphql-transformer-interfaces": "4.1.1",
+				"fs-extra": "^8.1.0",
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"graphql-transformer-common": "5.0.1",
+				"hjson": "^3.2.2",
+				"lodash": "^4.17.21",
+				"md5": "^2.3.0",
+				"object-hash": "^3.0.0",
+				"ts-dedent": "^2.0.0"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
+			"version": "4.1.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"graphql": "^15.5.0"
+			},
+			"peerDependencies": {
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.3.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-amplify/plugin-types": "^1.2.1",
+				"@aws-sdk/client-sts": "^3.624.0",
+				"is-ci": "^3.0.1",
+				"lodash.mergewith": "^4.6.2",
+				"semver": "^7.6.3",
+				"uuid": "^9.0.1",
+				"zod": "^3.22.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.2.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-amplify/storage/node_modules/@smithy/types": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-			"integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -384,20 +4309,3101 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-amplify/storage/node_modules/buffer": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-			"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-amplify/storage/node_modules/fast-xml-parser": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
-			"integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.651.1",
+				"@aws-sdk/client-sts": "3.651.1",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/credential-provider-node": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/eventstream-serde-browser": "^3.0.7",
+				"@smithy/eventstream-serde-config-resolver": "^3.0.4",
+				"@smithy/eventstream-serde-node": "^3.0.6",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-stream": "^3.1.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/credential-provider-node": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.651.1"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/core": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^2.4.1",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/signature-v4": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-stream": "^3.1.4",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.649.0",
+				"@aws-sdk/credential-provider-http": "3.649.0",
+				"@aws-sdk/credential-provider-process": "3.649.0",
+				"@aws-sdk/credential-provider-sso": "3.651.1",
+				"@aws-sdk/credential-provider-web-identity": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/credential-provider-imds": "^3.2.1",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.651.1"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.649.0",
+				"@aws-sdk/credential-provider-http": "3.649.0",
+				"@aws-sdk/credential-provider-ini": "3.651.1",
+				"@aws-sdk/credential-provider-process": "3.649.0",
+				"@aws-sdk/credential-provider-sso": "3.651.1",
+				"@aws-sdk/credential-provider-web-identity": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/credential-provider-imds": "^3.2.1",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.651.1",
+				"@aws-sdk/token-providers": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.649.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sso-oidc": "^3.649.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-endpoints": "^2.1.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sso": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.635.0",
+				"@aws-sdk/middleware-host-header": "3.620.0",
+				"@aws-sdk/middleware-logger": "3.609.0",
+				"@aws-sdk/middleware-recursion-detection": "3.620.0",
+				"@aws-sdk/middleware-user-agent": "3.637.0",
+				"@aws-sdk/region-config-resolver": "3.614.0",
+				"@aws-sdk/types": "3.609.0",
+				"@aws-sdk/util-endpoints": "3.637.0",
+				"@aws-sdk/util-user-agent-browser": "3.609.0",
+				"@aws-sdk/util-user-agent-node": "3.614.0",
+				"@smithy/config-resolver": "^3.0.5",
+				"@smithy/core": "^2.4.0",
+				"@smithy/fetch-http-handler": "^3.2.4",
+				"@smithy/hash-node": "^3.0.3",
+				"@smithy/invalid-dependency": "^3.0.3",
+				"@smithy/middleware-content-length": "^3.0.5",
+				"@smithy/middleware-endpoint": "^3.1.0",
+				"@smithy/middleware-retry": "^3.0.15",
+				"@smithy/middleware-serde": "^3.0.3",
+				"@smithy/middleware-stack": "^3.0.3",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/node-http-handler": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/smithy-client": "^3.2.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/url-parser": "^3.0.3",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.15",
+				"@smithy/util-defaults-mode-node": "^3.0.15",
+				"@smithy/util-endpoints": "^2.0.5",
+				"@smithy/util-middleware": "^3.0.3",
+				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.635.0",
+				"@aws-sdk/credential-provider-node": "3.637.0",
+				"@aws-sdk/middleware-host-header": "3.620.0",
+				"@aws-sdk/middleware-logger": "3.609.0",
+				"@aws-sdk/middleware-recursion-detection": "3.620.0",
+				"@aws-sdk/middleware-user-agent": "3.637.0",
+				"@aws-sdk/region-config-resolver": "3.614.0",
+				"@aws-sdk/types": "3.609.0",
+				"@aws-sdk/util-endpoints": "3.637.0",
+				"@aws-sdk/util-user-agent-browser": "3.609.0",
+				"@aws-sdk/util-user-agent-node": "3.614.0",
+				"@smithy/config-resolver": "^3.0.5",
+				"@smithy/core": "^2.4.0",
+				"@smithy/fetch-http-handler": "^3.2.4",
+				"@smithy/hash-node": "^3.0.3",
+				"@smithy/invalid-dependency": "^3.0.3",
+				"@smithy/middleware-content-length": "^3.0.5",
+				"@smithy/middleware-endpoint": "^3.1.0",
+				"@smithy/middleware-retry": "^3.0.15",
+				"@smithy/middleware-serde": "^3.0.3",
+				"@smithy/middleware-stack": "^3.0.3",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/node-http-handler": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/smithy-client": "^3.2.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/url-parser": "^3.0.3",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.15",
+				"@smithy/util-defaults-mode-node": "^3.0.15",
+				"@smithy/util-endpoints": "^2.0.5",
+				"@smithy/util-middleware": "^3.0.3",
+				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.637.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.651.1",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/credential-provider-node": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.651.1",
+				"@aws-sdk/credential-provider-node": "3.651.1",
+				"@aws-sdk/middleware-host-header": "3.649.0",
+				"@aws-sdk/middleware-logger": "3.649.0",
+				"@aws-sdk/middleware-recursion-detection": "3.649.0",
+				"@aws-sdk/middleware-user-agent": "3.649.0",
+				"@aws-sdk/region-config-resolver": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@aws-sdk/util-user-agent-browser": "3.649.0",
+				"@aws-sdk/util-user-agent-node": "3.649.0",
+				"@smithy/config-resolver": "^3.0.6",
+				"@smithy/core": "^2.4.1",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/hash-node": "^3.0.4",
+				"@smithy/invalid-dependency": "^3.0.4",
+				"@smithy/middleware-content-length": "^3.0.6",
+				"@smithy/middleware-endpoint": "^3.1.1",
+				"@smithy/middleware-retry": "^3.0.16",
+				"@smithy/middleware-serde": "^3.0.4",
+				"@smithy/middleware-stack": "^3.0.4",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/url-parser": "^3.0.4",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.16",
+				"@smithy/util-defaults-mode-node": "^3.0.16",
+				"@smithy/util-endpoints": "^2.1.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"@smithy/util-retry": "^3.0.4",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.651.1"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/core": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^2.4.1",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/signature-v4": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/fetch-http-handler": "^3.2.5",
+				"@smithy/node-http-handler": "^3.2.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/smithy-client": "^3.3.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-stream": "^3.1.4",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.649.0",
+				"@aws-sdk/credential-provider-http": "3.649.0",
+				"@aws-sdk/credential-provider-process": "3.649.0",
+				"@aws-sdk/credential-provider-sso": "3.651.1",
+				"@aws-sdk/credential-provider-web-identity": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/credential-provider-imds": "^3.2.1",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.651.1"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.649.0",
+				"@aws-sdk/credential-provider-http": "3.649.0",
+				"@aws-sdk/credential-provider-ini": "3.651.1",
+				"@aws-sdk/credential-provider-process": "3.649.0",
+				"@aws-sdk/credential-provider-sso": "3.651.1",
+				"@aws-sdk/credential-provider-web-identity": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/credential-provider-imds": "^3.2.1",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.651.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.651.1",
+				"@aws-sdk/token-providers": "3.649.0",
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.649.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@aws-sdk/util-endpoints": "3.649.0",
+				"@smithy/protocol-http": "^4.1.1",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.4",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/property-provider": "^3.1.4",
+				"@smithy/shared-ini-file-loader": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sso-oidc": "^3.649.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"@smithy/util-endpoints": "^2.1.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/types": "^3.4.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.649.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.649.0",
+				"@smithy/node-config-provider": "^3.1.5",
+				"@smithy/types": "^3.4.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/core": {
+			"version": "3.635.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^2.4.0",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/signature-v4": "^4.1.0",
+				"@smithy/smithy-client": "^3.2.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/util-middleware": "^3.0.3",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.620.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.635.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/fetch-http-handler": "^3.2.4",
+				"@smithy/node-http-handler": "^3.1.4",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/smithy-client": "^3.2.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/util-stream": "^3.1.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.620.1",
+				"@aws-sdk/credential-provider-http": "3.635.0",
+				"@aws-sdk/credential-provider-process": "3.620.1",
+				"@aws-sdk/credential-provider-sso": "3.637.0",
+				"@aws-sdk/credential-provider-web-identity": "3.621.0",
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/credential-provider-imds": "^3.2.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.637.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.620.1",
+				"@aws-sdk/credential-provider-http": "3.635.0",
+				"@aws-sdk/credential-provider-ini": "3.637.0",
+				"@aws-sdk/credential-provider-process": "3.620.1",
+				"@aws-sdk/credential-provider-sso": "3.637.0",
+				"@aws-sdk/credential-provider-web-identity": "3.621.0",
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/credential-provider-imds": "^3.2.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.620.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.637.0",
+				"@aws-sdk/token-providers": "3.614.0",
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.621.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.621.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.620.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.609.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.620.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@aws-sdk/util-endpoints": "3.637.0",
+				"@smithy/protocol-http": "^4.1.0",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.614.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/token-providers": {
+			"version": "3.614.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/property-provider": "^3.1.3",
+				"@smithy/shared-ini-file-loader": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sso-oidc": "^3.614.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/types": {
+			"version": "3.609.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.637.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/types": "^3.3.0",
+				"@smithy/util-endpoints": "^2.0.5",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.568.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.609.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/types": "^3.3.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.614.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.609.0",
+				"@smithy/node-config-provider": "^3.1.4",
+				"@smithy/types": "^3.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/abort-controller": {
+			"version": "3.1.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/config-resolver": {
+			"version": "3.0.8",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.6",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/core": {
+			"version": "2.4.3",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/middleware-endpoint": "^3.1.3",
+				"@smithy/middleware-retry": "^3.0.18",
+				"@smithy/middleware-serde": "^3.0.6",
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/smithy-client": "^3.3.2",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.6",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/credential-provider-imds": {
+			"version": "3.2.3",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/property-provider": "^3.1.6",
+				"@smithy/types": "^3.4.2",
+				"@smithy/url-parser": "^3.0.6",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-codec": {
+			"version": "3.1.5",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-browser": {
+			"version": "3.0.9",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^3.0.8",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-config-resolver": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-node": {
+			"version": "3.0.8",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^3.0.8",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-universal": {
+			"version": "3.0.8",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/eventstream-codec": "^3.1.5",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/fetch-http-handler": {
+			"version": "3.2.7",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/querystring-builder": "^3.0.6",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-base64": "^3.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/hash-node": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-buffer-from": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/invalid-dependency": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/is-array-buffer": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-content-length": {
+			"version": "3.0.8",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-endpoint": {
+			"version": "3.1.3",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/middleware-serde": "^3.0.6",
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.7",
+				"@smithy/types": "^3.4.2",
+				"@smithy/url-parser": "^3.0.6",
+				"@smithy/util-middleware": "^3.0.6",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-retry": {
+			"version": "3.0.18",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/service-error-classification": "^3.0.6",
+				"@smithy/smithy-client": "^3.3.2",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-middleware": "^3.0.6",
+				"@smithy/util-retry": "^3.0.6",
+				"tslib": "^2.6.2",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-serde": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-stack": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/node-config-provider": {
+			"version": "3.1.7",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/property-provider": "^3.1.6",
+				"@smithy/shared-ini-file-loader": "^3.1.7",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/node-http-handler": {
+			"version": "3.2.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/abort-controller": "^3.1.4",
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/querystring-builder": "^3.0.6",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/property-provider": {
+			"version": "3.1.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/protocol-http": {
+			"version": "4.1.3",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/querystring-builder": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/querystring-parser": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/service-error-classification": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/shared-ini-file-loader": {
+			"version": "3.1.7",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/signature-v4": {
+			"version": "4.1.3",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.6",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/smithy-client": {
+			"version": "3.3.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/middleware-endpoint": "^3.1.3",
+				"@smithy/middleware-stack": "^3.0.6",
+				"@smithy/protocol-http": "^4.1.3",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-stream": "^3.1.6",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/types": {
+			"version": "3.4.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/url-parser": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/querystring-parser": "^3.0.6",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-base64": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-body-length-browser": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-body-length-node": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-buffer-from": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-config-provider": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "3.0.18",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/property-provider": "^3.1.6",
+				"@smithy/smithy-client": "^3.3.2",
+				"@smithy/types": "^3.4.2",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-defaults-mode-node": {
+			"version": "3.0.18",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/config-resolver": "^3.0.8",
+				"@smithy/credential-provider-imds": "^3.2.3",
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/property-provider": "^3.1.6",
+				"@smithy/smithy-client": "^3.3.2",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-endpoints": {
+			"version": "2.1.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^3.1.7",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-hex-encoding": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-middleware": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-retry": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/service-error-classification": "^3.0.6",
+				"@smithy/types": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-stream": {
+			"version": "3.1.6",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/fetch-http-handler": "^3.2.7",
+				"@smithy/node-http-handler": "^3.2.2",
+				"@smithy/types": "^3.4.2",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-buffer-from": "^3.0.0",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-uri-escape": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-utf8": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/bowser": {
+			"version": "2.11.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/charenc": {
+			"version": "0.0.2",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/ci-info": {
+			"version": "3.9.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/crypt": {
+			"version": "0.0.2",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/fast-xml-parser": {
+			"version": "4.4.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
+				}
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/graphql": {
+			"version": "15.9.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.x"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/graphql-mapping-template": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/graphql-transformer-common": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "5.0.1",
+				"md5": "^2.2.1",
+				"pluralize": "8.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/hjson": {
+			"version": "3.2.2",
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"hjson": "bin/hjson"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/immer": {
+			"version": "9.0.21",
+			"inBundle": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/is-buffer": {
+			"version": "1.1.6",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/is-ci": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ci-info": "^3.2.0"
+			},
+			"bin": {
+				"is-ci": "bin.js"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/jsonfile": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/libphonenumber-js": {
+			"version": "1.9.47",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/lodash": {
+			"version": "4.17.21",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/lodash.mergewith": {
+			"version": "4.6.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/md5": {
+			"version": "2.3.0",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/object-hash": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/pluralize": {
+			"version": "8.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/semver": {
+			"version": "7.6.3",
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/strnum": {
+			"version": "1.0.5",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/ts-dedent": {
+			"version": "2.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.10"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/tslib": {
+			"version": "2.7.0",
+			"inBundle": true,
+			"license": "0BSD"
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/universalify": {
+			"version": "0.1.2",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/uuid": {
+			"version": "9.0.1",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-api-construct/node_modules/zod": {
+			"version": "3.23.8",
+			"inBundle": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-directives": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/graphql-directives/-/graphql-directives-1.1.0.tgz",
+			"integrity": "sha512-rcGfm8DsnD7Em1wYgNoq7yO+cE22mM0ssFYRWnHGsZOMX9Lh25HP1Ympt633V+raaTK3ND0gAlbVLxXzCN8XOg=="
+		},
+		"node_modules/@aws-amplify/graphql-docs-generator": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-4.2.1.tgz",
+			"integrity": "sha512-ReBlY5//mWOmO0FL2ndswB9ku+vpg/JTY9Wwemjm/ibyoLHU1ojtGkPBkKH0CzbpOkIuEkIBLIg9EZ2yca/6oA==",
+			"dependencies": {
+				"graphql": "^15.5.0",
+				"handlebars": "4.7.7",
+				"yargs": "^15.1.0"
+			},
+			"bin": {
+				"graphql-docs-generator": "bin/cli"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-generator": {
+			"version": "0.4.7",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.4.7.tgz",
+			"integrity": "sha512-/qvbd2A9E0adBQxNgQ9QMxyRjexborSDT5evz1Ytr/imOd2MGNNEQEhzlHSc5Lt3L4m+H3l8dFb/V7IHbx5vzw==",
+			"dependencies": {
+				"@aws-amplify/appsync-modelgen-plugin": "2.13.2",
+				"@aws-amplify/graphql-directives": "^1.0.1",
+				"@aws-amplify/graphql-docs-generator": "4.2.1",
+				"@aws-amplify/graphql-types-generator": "3.6.0",
+				"@graphql-codegen/core": "^2.6.6",
+				"@graphql-tools/apollo-engine-loader": "^8.0.0",
+				"graphql": "^15.5.0",
+				"prettier": "^1.19.1"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.6.0.tgz",
+			"integrity": "sha512-yjPXJ2dYZwtGvwwcEQ5RDNlwTsd/hUfD2Dgguo999Gu3mQjz7nV4l7CXD/Oxo/QzwtU/4rmTX69yadBpR+he3A==",
+			"dependencies": {
+				"@babel/generator": "7.0.0-beta.4",
+				"@babel/types": "7.0.0-beta.4",
+				"babel-generator": "^6.26.1",
+				"babel-types": "^6.26.0",
+				"change-case": "^4.1.1",
+				"common-tags": "^1.8.0",
+				"core-js": "^3.6.4",
+				"fs-extra": "^8.1.0",
+				"globby": "^11.1.0",
+				"graphql": "^15.5.0",
+				"inflected": "^2.0.4",
+				"prettier": "^1.19.1",
+				"rimraf": "^3.0.0",
+				"source-map-support": "^0.5.16",
+				"yargs": "^15.1.0"
+			},
+			"bin": {
+				"graphql-types-generator": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/@babel/generator": {
+			"version": "7.0.0-beta.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.4.tgz",
+			"integrity": "sha512-aLpZzf79oGT1bxnsadapfUWErDTcxVKrhvR5F8G27JFgH37+/ATrODMJ0/1D2CgQ/WStDX5B5znnWRv0NzW2JQ==",
+			"dependencies": {
+				"@babel/types": "7.0.0-beta.4",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.2.0",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/@babel/types": {
+			"version": "7.0.0-beta.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.4.tgz",
+			"integrity": "sha512-yLvBW5TTAgJwURAUAdZa1vrFTkwXXvk0Kw48LYvgxpyT/IaV8W4OIhxdVztAt5ruDQ/OFUwHpzWqk6TN3EfmWA==",
+			"dependencies": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.2.0",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/globby": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"dependencies": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@aws-amplify/graphql-types-generator/node_modules/universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/model-generator": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/model-generator/-/model-generator-1.0.8.tgz",
+			"integrity": "sha512-raf8S+d6qRhQDCahsV6QxEOTLWrdahscNdCCuC0NECqxueFZEy6Ju9LUiYUQrqXQafjfpNm88+fTWRFCcHJw4w==",
+			"dependencies": {
+				"@aws-amplify/backend-output-schemas": "^1.1.0",
+				"@aws-amplify/deployed-backend-client": "^1.4.1",
+				"@aws-amplify/graphql-generator": "^0.4.0",
+				"@aws-amplify/graphql-types-generator": "^3.6.0",
+				"@aws-amplify/platform-core": "^1.0.5",
+				"@aws-amplify/plugin-types": "^1.3.0",
+				"@aws-sdk/client-appsync": "^3.624.0",
+				"@aws-sdk/client-s3": "^3.624.0",
+				"@aws-sdk/credential-providers": "^3.624.0",
+				"@aws-sdk/types": "^3.609.0",
+				"graphql": "^15.8.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-amplify": "^3.624.0",
+				"@aws-sdk/client-cloudformation": "^3.624.0"
+			}
+		},
+		"node_modules/@aws-amplify/model-generator/node_modules/@aws-amplify/deployed-backend-client": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/deployed-backend-client/-/deployed-backend-client-1.4.1.tgz",
+			"integrity": "sha512-uvHaYR4HUGNLXvPMrgJbUlse5DEGFXoqJNxJYKn4FNKoSa8F0S5atSUqUpjKHFUp2Xu9VTXViPhqRDNUiRG8EA==",
+			"dependencies": {
+				"@aws-amplify/backend-output-schemas": "^1.2.0",
+				"@aws-amplify/platform-core": "^1.0.5",
+				"@aws-amplify/plugin-types": "^1.2.2",
+				"zod": "^3.22.2"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-amplify": "^3.624.0",
+				"@aws-sdk/client-cloudformation": "^3.624.0",
+				"@aws-sdk/client-s3": "^3.624.0",
+				"@aws-sdk/types": "^3.609.0"
+			}
+		},
+		"node_modules/@aws-amplify/model-generator/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+			"integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/model-generator/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/platform-core/-/platform-core-1.1.0.tgz",
+			"integrity": "sha512-9iOM+dpht1f52WUHPyaXyeF8Z27TNgqBS86JmIhcsqWltUsCqoQDKPVjaTj8No05oMzm+icWc96dPG/EZIE3jw==",
+			"dependencies": {
+				"@aws-amplify/plugin-types": "^1.2.1",
+				"@aws-sdk/client-sts": "^3.624.0",
+				"is-ci": "^3.0.1",
+				"lodash.mergewith": "^4.6.2",
+				"semver": "^7.6.3",
+				"uuid": "^9.0.1",
+				"zod": "^3.22.2"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-amplify/plugin-types": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+			"integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
+			"peerDependencies": {
+				"@aws-sdk/types": "^3.609.0",
+				"aws-cdk-lib": "^2.152.0",
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/client-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.667.0.tgz",
+			"integrity": "sha512-69nl3BXcAfn/zUdxpxC/5Bi4K46sMgTRFVKHkyiRFO8OQpNJDRzl6eGltESLqtf65rjWfswTDwfYrMd2+tnlDQ==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.667.0.tgz",
+			"integrity": "sha512-ThLLR0Zn15Rk8Y6rzzVtHREZU4NAsNj9oCiQcXj4/vlBl+J0MbiTCDUJTc559O+DIMekrjusLaPIKfTZmXXuhA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/client-sts": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.667.0.tgz",
+			"integrity": "sha512-SnvkDDuOAwXOxzhGfvvxK8JFFVApVvXrM6+nVmSYwuHjWdI+HwNcsRC6rxZ8uHQEz2fR0a810ckUwFVfpvtIoA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/core": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
+			"integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.667.0.tgz",
+			"integrity": "sha512-zZbrkkaPc54WXm+QAnpuv0LPNfsts0HPPd+oCECGs7IQRaFsGj187cwvPg9RMWDFZqpm64MdBDoA8OQHsqzYCw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.667.0.tgz",
+			"integrity": "sha512-sjtybFfERZWiqTY7fswBxKQLvUkiCucOWyqh3IaPo/4nE1PXRnaZCVG0+kRBPrYIxWqiVwytvZzMJy8sVZcG0A==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-stream": "^3.1.9",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.667.0.tgz",
+			"integrity": "sha512-NiEC2Sjut57ajbWEXLFtA8YWA06ulfuaSHOP4YxoQEsL3BjMOkKS1/5eVW2o6XkKVbwt0zbDYSTlIxU5klHpbQ==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.667.0.tgz",
+			"integrity": "sha512-+2oNexDvbQD9o5Xdtu1mGE25Nf2/C9KgMnkZzenbgCegw0P0YRdGrJklDF5Aag6lmb80a2vjoViuvm1ORzRAzw==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-ini": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.667.0.tgz",
+			"integrity": "sha512-HZHnvop32fKgsNHkdhVaul7UzQ25sEc0j9yqA4bjhtbk0ECl42kj3f1pJ+ZU/YD9ut8lMJs/vVqiOdNThVdeBw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.667.0.tgz",
+			"integrity": "sha512-GylJquSQVWlziaEmrX38KzQTWcFL5NKht4OAj7rdo75MssC0qNVSGT+ReFrXZzKQ65eIuRVCMdsp83oNH4nzbQ==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/token-providers": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.667.0.tgz",
+			"integrity": "sha512-t8CFlZMD/1p/8Cli3rvRiTJpjr/8BO64gw166AHgFZYSN2h95L2l1tcW0jpsc3PprA32nLg1iQVKYt4WGM4ugw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.667.0.tgz",
+			"integrity": "sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.667.0.tgz",
+			"integrity": "sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.667.0.tgz",
+			"integrity": "sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.667.0.tgz",
+			"integrity": "sha512-NJoPMV+9hpN90iZ2SgOpFmY6MJW71gGyT28kt0C68B0tBadYpT/J6WW8J7gxwdLA7d2CBwHbFGphTPWXXl+jzw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+			"integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/token-providers": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.667.0.tgz",
+			"integrity": "sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sso-oidc": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.667.0.tgz",
+			"integrity": "sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-endpoints": "^2.1.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.667.0.tgz",
+			"integrity": "sha512-y1pKlNzNpxzddM0QSnfIfIbi3Z9LTag1VDjYyZRbEGGSVip2J00qKsET+979nRezWMyJgw5GPBQR3Y+rN+jh0Q==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.667.0.tgz",
+			"integrity": "sha512-4OcWyWUAYRLwXMxqUqnDb/3LoassXvEJcwjiIKEa7p0JvtSa9VjCL6B8Vjw8C/N6YoqrlFEEvcN7SlwBEy74pA==",
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@smithy/signature-v4": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
+			"integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-amplify/platform-core/node_modules/fast-xml-parser": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
 			"funding": [
 				{
 					"type": "github",
@@ -413,6 +7419,59 @@
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-cdk/asset-awscli-v1": {
+			"version": "2.2.206",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.206.tgz",
+			"integrity": "sha512-l2eAROXoPOXNyXt3lGUEveHo/U8c0IX7RTjgf2qy1LcZw6IkUIIIy/erQ6bBqZ5SibRfFAoXSBBC+gFfGyZDcA==",
+			"peer": true
+		},
+		"node_modules/@aws-cdk/asset-kubectl-v20": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+			"integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
+			"peer": true
+		},
+		"node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+			"integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
+			"peer": true
+		},
+		"node_modules/@aws-cdk/cloud-assembly-schema": {
+			"version": "38.0.1",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
+			"integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
+			"bundleDependencies": [
+				"jsonschema",
+				"semver"
+			],
+			"peer": true,
+			"dependencies": {
+				"jsonschema": "^1.4.1",
+				"semver": "^7.6.3"
+			}
+		},
+		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+			"version": "1.4.1",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+			"version": "7.6.3",
+			"inBundle": true,
+			"license": "ISC",
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@aws-crypto/crc32": {
@@ -473,6 +7532,61 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@aws-crypto/crc32c": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+			"integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/crc32c/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/crc32c/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/crc32c/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/crc32c/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/@aws-crypto/ie11-detection": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
@@ -485,6 +7599,72 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/sha1-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+			"integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+			"dependencies": {
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha1-browser/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha1-browser/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
 			"version": "3.0.0",
@@ -549,6 +7729,2009 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
+		"node_modules/@aws-sdk/client-amplify": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-amplify/-/client-amplify-3.667.0.tgz",
+			"integrity": "sha512-7kytQ3SRUOq/Ry0SESJSf6DyIEoEi07D3+dv5hvD2krp9mXVaRkhqtRGGHkwyryx0uCw9wnl+7OMMuvGyusMtQ==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/client-sts": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/client-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.667.0.tgz",
+			"integrity": "sha512-69nl3BXcAfn/zUdxpxC/5Bi4K46sMgTRFVKHkyiRFO8OQpNJDRzl6eGltESLqtf65rjWfswTDwfYrMd2+tnlDQ==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.667.0.tgz",
+			"integrity": "sha512-ThLLR0Zn15Rk8Y6rzzVtHREZU4NAsNj9oCiQcXj4/vlBl+J0MbiTCDUJTc559O+DIMekrjusLaPIKfTZmXXuhA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/client-sts": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.667.0.tgz",
+			"integrity": "sha512-SnvkDDuOAwXOxzhGfvvxK8JFFVApVvXrM6+nVmSYwuHjWdI+HwNcsRC6rxZ8uHQEz2fR0a810ckUwFVfpvtIoA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/core": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
+			"integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.667.0.tgz",
+			"integrity": "sha512-zZbrkkaPc54WXm+QAnpuv0LPNfsts0HPPd+oCECGs7IQRaFsGj187cwvPg9RMWDFZqpm64MdBDoA8OQHsqzYCw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.667.0.tgz",
+			"integrity": "sha512-sjtybFfERZWiqTY7fswBxKQLvUkiCucOWyqh3IaPo/4nE1PXRnaZCVG0+kRBPrYIxWqiVwytvZzMJy8sVZcG0A==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-stream": "^3.1.9",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.667.0.tgz",
+			"integrity": "sha512-NiEC2Sjut57ajbWEXLFtA8YWA06ulfuaSHOP4YxoQEsL3BjMOkKS1/5eVW2o6XkKVbwt0zbDYSTlIxU5klHpbQ==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.667.0.tgz",
+			"integrity": "sha512-+2oNexDvbQD9o5Xdtu1mGE25Nf2/C9KgMnkZzenbgCegw0P0YRdGrJklDF5Aag6lmb80a2vjoViuvm1ORzRAzw==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-ini": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.667.0.tgz",
+			"integrity": "sha512-HZHnvop32fKgsNHkdhVaul7UzQ25sEc0j9yqA4bjhtbk0ECl42kj3f1pJ+ZU/YD9ut8lMJs/vVqiOdNThVdeBw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.667.0.tgz",
+			"integrity": "sha512-GylJquSQVWlziaEmrX38KzQTWcFL5NKht4OAj7rdo75MssC0qNVSGT+ReFrXZzKQ65eIuRVCMdsp83oNH4nzbQ==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/token-providers": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.667.0.tgz",
+			"integrity": "sha512-t8CFlZMD/1p/8Cli3rvRiTJpjr/8BO64gw166AHgFZYSN2h95L2l1tcW0jpsc3PprA32nLg1iQVKYt4WGM4ugw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.667.0.tgz",
+			"integrity": "sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.667.0.tgz",
+			"integrity": "sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.667.0.tgz",
+			"integrity": "sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.667.0.tgz",
+			"integrity": "sha512-NJoPMV+9hpN90iZ2SgOpFmY6MJW71gGyT28kt0C68B0tBadYpT/J6WW8J7gxwdLA7d2CBwHbFGphTPWXXl+jzw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+			"integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/token-providers": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.667.0.tgz",
+			"integrity": "sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sso-oidc": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.667.0.tgz",
+			"integrity": "sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-endpoints": "^2.1.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.667.0.tgz",
+			"integrity": "sha512-y1pKlNzNpxzddM0QSnfIfIbi3Z9LTag1VDjYyZRbEGGSVip2J00qKsET+979nRezWMyJgw5GPBQR3Y+rN+jh0Q==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.667.0.tgz",
+			"integrity": "sha512-4OcWyWUAYRLwXMxqUqnDb/3LoassXvEJcwjiIKEa7p0JvtSa9VjCL6B8Vjw8C/N6YoqrlFEEvcN7SlwBEy74pA==",
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@smithy/signature-v4": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
+			"integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-amplify/node_modules/fast-xml-parser": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
+				}
+			],
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-appsync/-/client-appsync-3.667.0.tgz",
+			"integrity": "sha512-WwofDLvZT1McCGdW6rhzj6s4aZKvZIGtJq/NbSsM8YZ9PnfAPTO9mDPMuhAiAukJ8i1FdqXJIXIrHWqd8H0p0Q==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/client-sts": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-stream": "^3.1.9",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/client-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.667.0.tgz",
+			"integrity": "sha512-69nl3BXcAfn/zUdxpxC/5Bi4K46sMgTRFVKHkyiRFO8OQpNJDRzl6eGltESLqtf65rjWfswTDwfYrMd2+tnlDQ==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.667.0.tgz",
+			"integrity": "sha512-ThLLR0Zn15Rk8Y6rzzVtHREZU4NAsNj9oCiQcXj4/vlBl+J0MbiTCDUJTc559O+DIMekrjusLaPIKfTZmXXuhA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/client-sts": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.667.0.tgz",
+			"integrity": "sha512-SnvkDDuOAwXOxzhGfvvxK8JFFVApVvXrM6+nVmSYwuHjWdI+HwNcsRC6rxZ8uHQEz2fR0a810ckUwFVfpvtIoA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/core": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
+			"integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.667.0.tgz",
+			"integrity": "sha512-zZbrkkaPc54WXm+QAnpuv0LPNfsts0HPPd+oCECGs7IQRaFsGj187cwvPg9RMWDFZqpm64MdBDoA8OQHsqzYCw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.667.0.tgz",
+			"integrity": "sha512-sjtybFfERZWiqTY7fswBxKQLvUkiCucOWyqh3IaPo/4nE1PXRnaZCVG0+kRBPrYIxWqiVwytvZzMJy8sVZcG0A==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-stream": "^3.1.9",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.667.0.tgz",
+			"integrity": "sha512-NiEC2Sjut57ajbWEXLFtA8YWA06ulfuaSHOP4YxoQEsL3BjMOkKS1/5eVW2o6XkKVbwt0zbDYSTlIxU5klHpbQ==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.667.0.tgz",
+			"integrity": "sha512-+2oNexDvbQD9o5Xdtu1mGE25Nf2/C9KgMnkZzenbgCegw0P0YRdGrJklDF5Aag6lmb80a2vjoViuvm1ORzRAzw==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-ini": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.667.0.tgz",
+			"integrity": "sha512-HZHnvop32fKgsNHkdhVaul7UzQ25sEc0j9yqA4bjhtbk0ECl42kj3f1pJ+ZU/YD9ut8lMJs/vVqiOdNThVdeBw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.667.0.tgz",
+			"integrity": "sha512-GylJquSQVWlziaEmrX38KzQTWcFL5NKht4OAj7rdo75MssC0qNVSGT+ReFrXZzKQ65eIuRVCMdsp83oNH4nzbQ==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/token-providers": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.667.0.tgz",
+			"integrity": "sha512-t8CFlZMD/1p/8Cli3rvRiTJpjr/8BO64gw166AHgFZYSN2h95L2l1tcW0jpsc3PprA32nLg1iQVKYt4WGM4ugw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.667.0.tgz",
+			"integrity": "sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.667.0.tgz",
+			"integrity": "sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.667.0.tgz",
+			"integrity": "sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.667.0.tgz",
+			"integrity": "sha512-NJoPMV+9hpN90iZ2SgOpFmY6MJW71gGyT28kt0C68B0tBadYpT/J6WW8J7gxwdLA7d2CBwHbFGphTPWXXl+jzw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+			"integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/token-providers": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.667.0.tgz",
+			"integrity": "sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sso-oidc": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.667.0.tgz",
+			"integrity": "sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-endpoints": "^2.1.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.667.0.tgz",
+			"integrity": "sha512-y1pKlNzNpxzddM0QSnfIfIbi3Z9LTag1VDjYyZRbEGGSVip2J00qKsET+979nRezWMyJgw5GPBQR3Y+rN+jh0Q==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.667.0.tgz",
+			"integrity": "sha512-4OcWyWUAYRLwXMxqUqnDb/3LoassXvEJcwjiIKEa7p0JvtSa9VjCL6B8Vjw8C/N6YoqrlFEEvcN7SlwBEy74pA==",
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@smithy/signature-v4": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
+			"integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-appsync/node_modules/fast-xml-parser": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
+				}
+			],
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.667.0.tgz",
+			"integrity": "sha512-po7f4cdaw8zVl6X7U6gnQ5jx023mg5mGxrcXdQf+1n3xYK8mZnY3Sovv4ZPXbBwqdiK3HhL4kkLBabyQ5CMEFQ==",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/client-sts": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"@smithy/util-waiter": "^3.1.6",
+				"tslib": "^2.6.2",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.667.0.tgz",
+			"integrity": "sha512-69nl3BXcAfn/zUdxpxC/5Bi4K46sMgTRFVKHkyiRFO8OQpNJDRzl6eGltESLqtf65rjWfswTDwfYrMd2+tnlDQ==",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.667.0.tgz",
+			"integrity": "sha512-ThLLR0Zn15Rk8Y6rzzVtHREZU4NAsNj9oCiQcXj4/vlBl+J0MbiTCDUJTc559O+DIMekrjusLaPIKfTZmXXuhA==",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sts": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.667.0.tgz",
+			"integrity": "sha512-SnvkDDuOAwXOxzhGfvvxK8JFFVApVvXrM6+nVmSYwuHjWdI+HwNcsRC6rxZ8uHQEz2fR0a810ckUwFVfpvtIoA==",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/core": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
+			"integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.667.0.tgz",
+			"integrity": "sha512-zZbrkkaPc54WXm+QAnpuv0LPNfsts0HPPd+oCECGs7IQRaFsGj187cwvPg9RMWDFZqpm64MdBDoA8OQHsqzYCw==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.667.0.tgz",
+			"integrity": "sha512-sjtybFfERZWiqTY7fswBxKQLvUkiCucOWyqh3IaPo/4nE1PXRnaZCVG0+kRBPrYIxWqiVwytvZzMJy8sVZcG0A==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-stream": "^3.1.9",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.667.0.tgz",
+			"integrity": "sha512-NiEC2Sjut57ajbWEXLFtA8YWA06ulfuaSHOP4YxoQEsL3BjMOkKS1/5eVW2o6XkKVbwt0zbDYSTlIxU5klHpbQ==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.667.0.tgz",
+			"integrity": "sha512-+2oNexDvbQD9o5Xdtu1mGE25Nf2/C9KgMnkZzenbgCegw0P0YRdGrJklDF5Aag6lmb80a2vjoViuvm1ORzRAzw==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-ini": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.667.0.tgz",
+			"integrity": "sha512-HZHnvop32fKgsNHkdhVaul7UzQ25sEc0j9yqA4bjhtbk0ECl42kj3f1pJ+ZU/YD9ut8lMJs/vVqiOdNThVdeBw==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.667.0.tgz",
+			"integrity": "sha512-GylJquSQVWlziaEmrX38KzQTWcFL5NKht4OAj7rdo75MssC0qNVSGT+ReFrXZzKQ65eIuRVCMdsp83oNH4nzbQ==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/token-providers": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.667.0.tgz",
+			"integrity": "sha512-t8CFlZMD/1p/8Cli3rvRiTJpjr/8BO64gw166AHgFZYSN2h95L2l1tcW0jpsc3PprA32nLg1iQVKYt4WGM4ugw==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.667.0.tgz",
+			"integrity": "sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.667.0.tgz",
+			"integrity": "sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.667.0.tgz",
+			"integrity": "sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.667.0.tgz",
+			"integrity": "sha512-NJoPMV+9hpN90iZ2SgOpFmY6MJW71gGyT28kt0C68B0tBadYpT/J6WW8J7gxwdLA7d2CBwHbFGphTPWXXl+jzw==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+			"integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/token-providers": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.667.0.tgz",
+			"integrity": "sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sso-oidc": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.667.0.tgz",
+			"integrity": "sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-endpoints": "^2.1.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.667.0.tgz",
+			"integrity": "sha512-y1pKlNzNpxzddM0QSnfIfIbi3Z9LTag1VDjYyZRbEGGSVip2J00qKsET+979nRezWMyJgw5GPBQR3Y+rN+jh0Q==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.667.0.tgz",
+			"integrity": "sha512-4OcWyWUAYRLwXMxqUqnDb/3LoassXvEJcwjiIKEa7p0JvtSa9VjCL6B8Vjw8C/N6YoqrlFEEvcN7SlwBEy74pA==",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/signature-v4": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
+			"integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudformation/node_modules/fast-xml-parser": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
+				}
+			],
+			"peer": true,
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-sdk/client-cognito-identity": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.667.0.tgz",
+			"integrity": "sha512-VHkXM4SKa4wE1YwLTrfODesffg5/QJI1s3lrOwzMXQ3JDaPSEeeSnGn+dVZVnSG6Tg/bkKm45JMXIJmW1zG6Tw==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/client-sts": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/@aws-sdk/client-cognito-identity-provider": {
 			"version": "3.583.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.583.0.tgz",
@@ -600,58 +9783,7 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-firehose/-/client-firehose-3.621.0.tgz",
-			"integrity": "sha512-XAjAkXdb35PDvBYph609Fxn4g00HYH/U6N4+KjF9gLQrdTU+wkjf3D9YD02DZNbApJVcu4eIxWh/8M25YkW02A==",
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.621.0",
-				"@aws-sdk/client-sts": "3.621.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/credential-provider-node": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
-				"@smithy/util-base64": "^3.0.0",
-				"@smithy/util-body-length-browser": "^3.0.0",
-				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
-				"@smithy/util-utf8": "^3.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-crypto/sha256-browser": {
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
 			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
@@ -665,7 +9797,7 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
@@ -677,7 +9809,7 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-crypto/sha256-js": {
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
 			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
@@ -690,7 +9822,7 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-crypto/supports-web-crypto": {
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/supports-web-crypto": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
 			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
@@ -698,7 +9830,7 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-crypto/util": {
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
 			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
@@ -708,7 +9840,7 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
@@ -720,47 +9852,47 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/client-sso": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.621.0.tgz",
-			"integrity": "sha512-xpKfikN4u0BaUYZA9FGUMkkDmfoIP0Q03+A86WjqDWhcOoqNA1DkHsE4kZ+r064ifkPUfcNuUvlkVTEoBZoFjA==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.667.0.tgz",
+			"integrity": "sha512-69nl3BXcAfn/zUdxpxC/5Bi4K46sMgTRFVKHkyiRFO8OQpNJDRzl6eGltESLqtf65rjWfswTDwfYrMd2+tnlDQ==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -768,48 +9900,48 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.621.0.tgz",
-			"integrity": "sha512-mMjk3mFUwV2Y68POf1BQMTF+F6qxt5tPu6daEUCNGC9Cenk3h2YXQQoS4/eSyYzuBiYk3vx49VgleRvdvkg8rg==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.667.0.tgz",
+			"integrity": "sha512-ThLLR0Zn15Rk8Y6rzzVtHREZU4NAsNj9oCiQcXj4/vlBl+J0MbiTCDUJTc559O+DIMekrjusLaPIKfTZmXXuhA==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/credential-provider-node": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -817,52 +9949,52 @@
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.621.0"
+				"@aws-sdk/client-sts": "^3.667.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/client-sts": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.621.0.tgz",
-			"integrity": "sha512-707uiuReSt+nAx6d0c21xLjLm2lxeKc7padxjv92CIrIocnQSlJPxSCM7r5zBhwiahJA6MNQwmTl2xznU67KgA==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.667.0.tgz",
+			"integrity": "sha512-SnvkDDuOAwXOxzhGfvvxK8JFFVApVvXrM6+nVmSYwuHjWdI+HwNcsRC6rxZ8uHQEz2fR0a810ckUwFVfpvtIoA==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.621.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/credential-provider-node": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -870,18 +10002,20 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/core": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.621.0.tgz",
-			"integrity": "sha512-CtOwWmDdEiINkGXD93iGfXjN0WmCp9l45cDWHHGa8lRgEDyhuL7bwd/pH5aSzj0j8SiQBG2k0S7DHbd5RaqvbQ==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/core": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
+			"integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==",
 			"dependencies": {
-				"@smithy/core": "^2.3.1",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/signature-v4": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/util-middleware": "^3.0.3",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
 				"fast-xml-parser": "4.4.1",
 				"tslib": "^2.6.2"
 			},
@@ -889,269 +10023,278 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.620.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
-			"integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.667.0.tgz",
+			"integrity": "sha512-zZbrkkaPc54WXm+QAnpuv0LPNfsts0HPPd+oCECGs7IQRaFsGj187cwvPg9RMWDFZqpm64MdBDoA8OQHsqzYCw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.621.0.tgz",
-			"integrity": "sha512-/jc2tEsdkT1QQAI5Dvoci50DbSxtJrevemwFsm0B73pwCcOQZ5ZwwSdVqGsPutzYzUVx3bcXg3LRL7jLACqRIg==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.667.0.tgz",
+			"integrity": "sha512-sjtybFfERZWiqTY7fswBxKQLvUkiCucOWyqh3IaPo/4nE1PXRnaZCVG0+kRBPrYIxWqiVwytvZzMJy8sVZcG0A==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/util-stream": "^3.1.3",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-stream": "^3.1.9",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.621.0.tgz",
-			"integrity": "sha512-0EWVnSc+JQn5HLnF5Xv405M8n4zfdx9gyGdpnCmAmFqEDHA8LmBdxJdpUk1Ovp/I5oPANhjojxabIW5f1uU0RA==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.667.0.tgz",
+			"integrity": "sha512-NiEC2Sjut57ajbWEXLFtA8YWA06ulfuaSHOP4YxoQEsL3BjMOkKS1/5eVW2o6XkKVbwt0zbDYSTlIxU5klHpbQ==",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.620.1",
-				"@aws-sdk/credential-provider-http": "3.621.0",
-				"@aws-sdk/credential-provider-process": "3.620.1",
-				"@aws-sdk/credential-provider-sso": "3.621.0",
-				"@aws-sdk/credential-provider-web-identity": "3.621.0",
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/credential-provider-imds": "^3.2.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			},
-			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.621.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.621.0.tgz",
-			"integrity": "sha512-4JqpccUgz5Snanpt2+53hbOBbJQrSFq7E1sAAbgY6BKVQUsW5qyXqnjvSF32kDeKa5JpBl3bBWLZl04IadcPHw==",
-			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.620.1",
-				"@aws-sdk/credential-provider-http": "3.621.0",
-				"@aws-sdk/credential-provider-ini": "3.621.0",
-				"@aws-sdk/credential-provider-process": "3.620.1",
-				"@aws-sdk/credential-provider-sso": "3.621.0",
-				"@aws-sdk/credential-provider-web-identity": "3.621.0",
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/credential-provider-imds": "^3.2.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.620.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
-			"integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.621.0.tgz",
-			"integrity": "sha512-Kza0jcFeA/GEL6xJlzR2KFf1PfZKMFnxfGzJzl5yN7EjoGdMijl34KaRyVnfRjnCWcsUpBWKNIDk9WZVMY9yiw==",
-			"dependencies": {
-				"@aws-sdk/client-sso": "3.621.0",
-				"@aws-sdk/token-providers": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
-			"integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
-			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.621.0"
+				"@aws-sdk/client-sts": "^3.667.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.620.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
-			"integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.667.0.tgz",
+			"integrity": "sha512-+2oNexDvbQD9o5Xdtu1mGE25Nf2/C9KgMnkZzenbgCegw0P0YRdGrJklDF5Aag6lmb80a2vjoViuvm1ORzRAzw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-ini": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.609.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
-			"integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.667.0.tgz",
+			"integrity": "sha512-HZHnvop32fKgsNHkdhVaul7UzQ25sEc0j9yqA4bjhtbk0ECl42kj3f1pJ+ZU/YD9ut8lMJs/vVqiOdNThVdeBw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.620.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
-			"integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.667.0.tgz",
+			"integrity": "sha512-GylJquSQVWlziaEmrX38KzQTWcFL5NKht4OAj7rdo75MssC0qNVSGT+ReFrXZzKQ65eIuRVCMdsp83oNH4nzbQ==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/client-sso": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/token-providers": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.620.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz",
-			"integrity": "sha512-bvS6etn+KsuL32ubY5D3xNof1qkenpbJXf/ugGXbg0n98DvDFQ/F+SMLxHgbnER5dsKYchNnhmtI6/FC3HFu/A==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.667.0.tgz",
+			"integrity": "sha512-t8CFlZMD/1p/8Cli3rvRiTJpjr/8BO64gw166AHgFZYSN2h95L2l1tcW0jpsc3PprA32nLg1iQVKYt4WGM4ugw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.667.0.tgz",
+			"integrity": "sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
-			"integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.667.0.tgz",
+			"integrity": "sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.667.0.tgz",
+			"integrity": "sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.667.0.tgz",
+			"integrity": "sha512-NJoPMV+9hpN90iZ2SgOpFmY6MJW71gGyT28kt0C68B0tBadYpT/J6WW8J7gxwdLA7d2CBwHbFGphTPWXXl+jzw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+			"integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-config-provider": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.3",
+				"@smithy/util-middleware": "^3.0.7",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/token-providers": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
-			"integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.667.0.tgz",
+			"integrity": "sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sso-oidc": "^3.614.0"
+				"@aws-sdk/client-sso-oidc": "^3.667.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/types": {
-			"version": "3.609.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-			"integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
 			"dependencies": {
-				"@smithy/types": "^3.3.0",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
-			"integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.667.0.tgz",
+			"integrity": "sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/types": "^3.3.0",
-				"@smithy/util-endpoints": "^2.0.5",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-endpoints": "^2.1.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.609.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
-			"integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.667.0.tgz",
+			"integrity": "sha512-y1pKlNzNpxzddM0QSnfIfIbi3Z9LTag1VDjYyZRbEGGSVip2J00qKsET+979nRezWMyJgw5GPBQR3Y+rN+jh0Q==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
-			"integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.667.0.tgz",
+			"integrity": "sha512-4OcWyWUAYRLwXMxqUqnDb/3LoassXvEJcwjiIKEa7p0JvtSa9VjCL6B8Vjw8C/N6YoqrlFEEvcN7SlwBEy74pA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1166,16 +10309,16 @@
 				}
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@smithy/signature-v4": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.4.tgz",
-			"integrity": "sha512-72MiK7xYukNsnLJI9NqvUHqTu0ziEsfMsYNlWpiJfuGQnCTFKpckThlEatirvcA/LmT1h7rRO+pJD06PYsPu9Q==",
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/signature-v4": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
+			"integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^3.0.0",
-				"@smithy/protocol-http": "^4.1.3",
-				"@smithy/types": "^3.4.2",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-hex-encoding": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.6",
+				"@smithy/util-middleware": "^3.0.7",
 				"@smithy/util-uri-escape": "^3.0.0",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
@@ -1184,18 +10327,7 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@smithy/util-buffer-from": {
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-buffer-from": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
 			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
@@ -1207,7 +10339,7 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
 			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
@@ -1218,7 +10350,7 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-firehose/node_modules/fast-xml-parser": {
+		"node_modules/@aws-sdk/client-cognito-identity/node_modules/fast-xml-parser": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
 			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
@@ -1239,62 +10371,75 @@
 				"fxparser": "src/cli/cli.js"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.621.0.tgz",
-			"integrity": "sha512-53Omt/beFmTQPjQNpMuPMk5nMzYVsXCRiO+MeqygZEKYG1fWw/UGluCWVbi7WjClOHacsW8lQcsqIRvkPDFNag==",
+		"node_modules/@aws-sdk/client-s3": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.667.0.tgz",
+			"integrity": "sha512-WKkjRJe93epfIWZa+PUgvMvDQ7IObr4poxqx/3YIsl8FXMSgJP5Woc1kdjeRrfpPWHGTm9O1Bi7XFulzEzUwQA==",
 			"dependencies": {
+				"@aws-crypto/sha1-browser": "5.2.0",
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.621.0",
-				"@aws-sdk/client-sts": "3.621.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/credential-provider-node": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/eventstream-serde-browser": "^3.0.5",
-				"@smithy/eventstream-serde-config-resolver": "^3.0.3",
-				"@smithy/eventstream-serde-node": "^3.0.4",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/client-sts": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-bucket-endpoint": "3.667.0",
+				"@aws-sdk/middleware-expect-continue": "3.667.0",
+				"@aws-sdk/middleware-flexible-checksums": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-location-constraint": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-sdk-s3": "3.667.0",
+				"@aws-sdk/middleware-ssec": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/signature-v4-multi-region": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@aws-sdk/xml-builder": "3.662.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/eventstream-serde-browser": "^3.0.10",
+				"@smithy/eventstream-serde-config-resolver": "^3.0.7",
+				"@smithy/eventstream-serde-node": "^3.0.9",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-blob-browser": "^3.1.6",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/hash-stream-node": "^3.1.6",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/md5-js": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-stream": "^3.1.9",
 				"@smithy/util-utf8": "^3.0.0",
-				"@smithy/util-waiter": "^3.1.2",
+				"@smithy/util-waiter": "^3.1.6",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-crypto/sha256-browser": {
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-browser": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
 			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
@@ -1308,7 +10453,7 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
@@ -1320,7 +10465,7 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-crypto/sha256-js": {
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-js": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
 			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
@@ -1333,7 +10478,7 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-crypto/supports-web-crypto": {
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/supports-web-crypto": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
 			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
@@ -1341,7 +10486,7 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-crypto/util": {
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/util": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
 			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
@@ -1351,7 +10496,7 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
@@ -1363,47 +10508,47 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/client-sso": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.621.0.tgz",
-			"integrity": "sha512-xpKfikN4u0BaUYZA9FGUMkkDmfoIP0Q03+A86WjqDWhcOoqNA1DkHsE4kZ+r064ifkPUfcNuUvlkVTEoBZoFjA==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.667.0.tgz",
+			"integrity": "sha512-69nl3BXcAfn/zUdxpxC/5Bi4K46sMgTRFVKHkyiRFO8OQpNJDRzl6eGltESLqtf65rjWfswTDwfYrMd2+tnlDQ==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -1411,48 +10556,48 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.621.0.tgz",
-			"integrity": "sha512-mMjk3mFUwV2Y68POf1BQMTF+F6qxt5tPu6daEUCNGC9Cenk3h2YXQQoS4/eSyYzuBiYk3vx49VgleRvdvkg8rg==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.667.0.tgz",
+			"integrity": "sha512-ThLLR0Zn15Rk8Y6rzzVtHREZU4NAsNj9oCiQcXj4/vlBl+J0MbiTCDUJTc559O+DIMekrjusLaPIKfTZmXXuhA==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/credential-provider-node": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -1460,52 +10605,52 @@
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.621.0"
+				"@aws-sdk/client-sts": "^3.667.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/client-sts": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.621.0.tgz",
-			"integrity": "sha512-707uiuReSt+nAx6d0c21xLjLm2lxeKc7padxjv92CIrIocnQSlJPxSCM7r5zBhwiahJA6MNQwmTl2xznU67KgA==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.667.0.tgz",
+			"integrity": "sha512-SnvkDDuOAwXOxzhGfvvxK8JFFVApVvXrM6+nVmSYwuHjWdI+HwNcsRC6rxZ8uHQEz2fR0a810ckUwFVfpvtIoA==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.621.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/credential-provider-node": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -1513,18 +10658,20 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/core": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.621.0.tgz",
-			"integrity": "sha512-CtOwWmDdEiINkGXD93iGfXjN0WmCp9l45cDWHHGa8lRgEDyhuL7bwd/pH5aSzj0j8SiQBG2k0S7DHbd5RaqvbQ==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
+			"integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==",
 			"dependencies": {
-				"@smithy/core": "^2.3.1",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/signature-v4": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/util-middleware": "^3.0.3",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
 				"fast-xml-parser": "4.4.1",
 				"tslib": "^2.6.2"
 			},
@@ -1532,269 +10679,278 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.620.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
-			"integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.667.0.tgz",
+			"integrity": "sha512-zZbrkkaPc54WXm+QAnpuv0LPNfsts0HPPd+oCECGs7IQRaFsGj187cwvPg9RMWDFZqpm64MdBDoA8OQHsqzYCw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.621.0.tgz",
-			"integrity": "sha512-/jc2tEsdkT1QQAI5Dvoci50DbSxtJrevemwFsm0B73pwCcOQZ5ZwwSdVqGsPutzYzUVx3bcXg3LRL7jLACqRIg==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.667.0.tgz",
+			"integrity": "sha512-sjtybFfERZWiqTY7fswBxKQLvUkiCucOWyqh3IaPo/4nE1PXRnaZCVG0+kRBPrYIxWqiVwytvZzMJy8sVZcG0A==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/util-stream": "^3.1.3",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-stream": "^3.1.9",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.621.0.tgz",
-			"integrity": "sha512-0EWVnSc+JQn5HLnF5Xv405M8n4zfdx9gyGdpnCmAmFqEDHA8LmBdxJdpUk1Ovp/I5oPANhjojxabIW5f1uU0RA==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.667.0.tgz",
+			"integrity": "sha512-NiEC2Sjut57ajbWEXLFtA8YWA06ulfuaSHOP4YxoQEsL3BjMOkKS1/5eVW2o6XkKVbwt0zbDYSTlIxU5klHpbQ==",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.620.1",
-				"@aws-sdk/credential-provider-http": "3.621.0",
-				"@aws-sdk/credential-provider-process": "3.620.1",
-				"@aws-sdk/credential-provider-sso": "3.621.0",
-				"@aws-sdk/credential-provider-web-identity": "3.621.0",
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/credential-provider-imds": "^3.2.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			},
-			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.621.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.621.0.tgz",
-			"integrity": "sha512-4JqpccUgz5Snanpt2+53hbOBbJQrSFq7E1sAAbgY6BKVQUsW5qyXqnjvSF32kDeKa5JpBl3bBWLZl04IadcPHw==",
-			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.620.1",
-				"@aws-sdk/credential-provider-http": "3.621.0",
-				"@aws-sdk/credential-provider-ini": "3.621.0",
-				"@aws-sdk/credential-provider-process": "3.620.1",
-				"@aws-sdk/credential-provider-sso": "3.621.0",
-				"@aws-sdk/credential-provider-web-identity": "3.621.0",
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/credential-provider-imds": "^3.2.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.620.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
-			"integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.621.0.tgz",
-			"integrity": "sha512-Kza0jcFeA/GEL6xJlzR2KFf1PfZKMFnxfGzJzl5yN7EjoGdMijl34KaRyVnfRjnCWcsUpBWKNIDk9WZVMY9yiw==",
-			"dependencies": {
-				"@aws-sdk/client-sso": "3.621.0",
-				"@aws-sdk/token-providers": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
-			"integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
-			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.621.0"
+				"@aws-sdk/client-sts": "^3.667.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.620.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
-			"integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.667.0.tgz",
+			"integrity": "sha512-+2oNexDvbQD9o5Xdtu1mGE25Nf2/C9KgMnkZzenbgCegw0P0YRdGrJklDF5Aag6lmb80a2vjoViuvm1ORzRAzw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-ini": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.609.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
-			"integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.667.0.tgz",
+			"integrity": "sha512-HZHnvop32fKgsNHkdhVaul7UzQ25sEc0j9yqA4bjhtbk0ECl42kj3f1pJ+ZU/YD9ut8lMJs/vVqiOdNThVdeBw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.620.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
-			"integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.667.0.tgz",
+			"integrity": "sha512-GylJquSQVWlziaEmrX38KzQTWcFL5NKht4OAj7rdo75MssC0qNVSGT+ReFrXZzKQ65eIuRVCMdsp83oNH4nzbQ==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/client-sso": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/token-providers": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.620.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz",
-			"integrity": "sha512-bvS6etn+KsuL32ubY5D3xNof1qkenpbJXf/ugGXbg0n98DvDFQ/F+SMLxHgbnER5dsKYchNnhmtI6/FC3HFu/A==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.667.0.tgz",
+			"integrity": "sha512-t8CFlZMD/1p/8Cli3rvRiTJpjr/8BO64gw166AHgFZYSN2h95L2l1tcW0jpsc3PprA32nLg1iQVKYt4WGM4ugw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.667.0.tgz",
+			"integrity": "sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
-			"integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.667.0.tgz",
+			"integrity": "sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.667.0.tgz",
+			"integrity": "sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.667.0.tgz",
+			"integrity": "sha512-NJoPMV+9hpN90iZ2SgOpFmY6MJW71gGyT28kt0C68B0tBadYpT/J6WW8J7gxwdLA7d2CBwHbFGphTPWXXl+jzw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+			"integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-config-provider": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.3",
+				"@smithy/util-middleware": "^3.0.7",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/token-providers": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
-			"integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.667.0.tgz",
+			"integrity": "sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sso-oidc": "^3.614.0"
+				"@aws-sdk/client-sso-oidc": "^3.667.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/types": {
-			"version": "3.609.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-			"integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
 			"dependencies": {
-				"@smithy/types": "^3.3.0",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
-			"integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.667.0.tgz",
+			"integrity": "sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/types": "^3.3.0",
-				"@smithy/util-endpoints": "^2.0.5",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-endpoints": "^2.1.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.609.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
-			"integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.667.0.tgz",
+			"integrity": "sha512-y1pKlNzNpxzddM0QSnfIfIbi3Z9LTag1VDjYyZRbEGGSVip2J00qKsET+979nRezWMyJgw5GPBQR3Y+rN+jh0Q==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
-			"integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.667.0.tgz",
+			"integrity": "sha512-4OcWyWUAYRLwXMxqUqnDb/3LoassXvEJcwjiIKEa7p0JvtSa9VjCL6B8Vjw8C/N6YoqrlFEEvcN7SlwBEy74pA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1809,16 +10965,26 @@
 				}
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/signature-v4": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.4.tgz",
-			"integrity": "sha512-72MiK7xYukNsnLJI9NqvUHqTu0ziEsfMsYNlWpiJfuGQnCTFKpckThlEatirvcA/LmT1h7rRO+pJD06PYsPu9Q==",
+		"node_modules/@aws-sdk/client-s3/node_modules/@smithy/md5-js": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.7.tgz",
+			"integrity": "sha512-+wco9IN9uOW4tNGkZIqTR6IXyfO7Z8A+IOq82QCRn/f/xcmt7H1fXwmQVbfDSvbeFwfNnhv7s+u0G9PzPG6o2w==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@smithy/signature-v4": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
+			"integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^3.0.0",
-				"@smithy/protocol-http": "^4.1.3",
-				"@smithy/types": "^3.4.2",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-hex-encoding": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.6",
+				"@smithy/util-middleware": "^3.0.7",
 				"@smithy/util-uri-escape": "^3.0.0",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
@@ -1827,18 +10993,7 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/util-buffer-from": {
+		"node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-buffer-from": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
 			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
@@ -1850,7 +11005,7 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+		"node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
 			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
@@ -1861,7 +11016,7 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-kinesis/node_modules/fast-xml-parser": {
+		"node_modules/@aws-sdk/client-s3/node_modules/fast-xml-parser": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
 			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
@@ -1882,58 +11037,60 @@
 				"fxparser": "src/cli/cli.js"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-personalize-events/-/client-personalize-events-3.621.0.tgz",
-			"integrity": "sha512-qkVkqYvOe3WVuVNL/gRITGYFfHJCx2ijGFK7H3hNUJH3P4AwskmouAd1pWf+3cbGedRnj2is7iw7E602LeJIHA==",
+		"node_modules/@aws-sdk/client-ssm": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.667.0.tgz",
+			"integrity": "sha512-P8N2UkRLHqBtyjD3roD4cvTSVy5Z4qy66aAX/7ry6JLDetUO9ILQsimv67l5WxosYiEoHFRHmZ3urON3ETsY2A==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.621.0",
-				"@aws-sdk/client-sts": "3.621.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/credential-provider-node": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/client-sts": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
 				"@smithy/util-utf8": "^3.0.0",
-				"tslib": "^2.6.2"
+				"@smithy/util-waiter": "^3.1.6",
+				"tslib": "^2.6.2",
+				"uuid": "^9.0.1"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-crypto/sha256-browser": {
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/sha256-browser": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
 			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
@@ -1947,7 +11104,7 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
@@ -1959,7 +11116,7 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-crypto/sha256-js": {
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/sha256-js": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
 			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
@@ -1972,7 +11129,7 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-crypto/supports-web-crypto": {
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/supports-web-crypto": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
 			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
@@ -1980,7 +11137,7 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-crypto/util": {
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/util": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
 			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
@@ -1990,7 +11147,7 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
@@ -2002,47 +11159,47 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/client-sso": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.621.0.tgz",
-			"integrity": "sha512-xpKfikN4u0BaUYZA9FGUMkkDmfoIP0Q03+A86WjqDWhcOoqNA1DkHsE4kZ+r064ifkPUfcNuUvlkVTEoBZoFjA==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.667.0.tgz",
+			"integrity": "sha512-69nl3BXcAfn/zUdxpxC/5Bi4K46sMgTRFVKHkyiRFO8OQpNJDRzl6eGltESLqtf65rjWfswTDwfYrMd2+tnlDQ==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -2050,48 +11207,48 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.621.0.tgz",
-			"integrity": "sha512-mMjk3mFUwV2Y68POf1BQMTF+F6qxt5tPu6daEUCNGC9Cenk3h2YXQQoS4/eSyYzuBiYk3vx49VgleRvdvkg8rg==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.667.0.tgz",
+			"integrity": "sha512-ThLLR0Zn15Rk8Y6rzzVtHREZU4NAsNj9oCiQcXj4/vlBl+J0MbiTCDUJTc559O+DIMekrjusLaPIKfTZmXXuhA==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/credential-provider-node": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -2099,52 +11256,52 @@
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.621.0"
+				"@aws-sdk/client-sts": "^3.667.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/client-sts": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.621.0.tgz",
-			"integrity": "sha512-707uiuReSt+nAx6d0c21xLjLm2lxeKc7padxjv92CIrIocnQSlJPxSCM7r5zBhwiahJA6MNQwmTl2xznU67KgA==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sts": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.667.0.tgz",
+			"integrity": "sha512-SnvkDDuOAwXOxzhGfvvxK8JFFVApVvXrM6+nVmSYwuHjWdI+HwNcsRC6rxZ8uHQEz2fR0a810ckUwFVfpvtIoA==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/client-sso-oidc": "3.621.0",
-				"@aws-sdk/core": "3.621.0",
-				"@aws-sdk/credential-provider-node": "3.621.0",
-				"@aws-sdk/middleware-host-header": "3.620.0",
-				"@aws-sdk/middleware-logger": "3.609.0",
-				"@aws-sdk/middleware-recursion-detection": "3.620.0",
-				"@aws-sdk/middleware-user-agent": "3.620.0",
-				"@aws-sdk/region-config-resolver": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@aws-sdk/util-user-agent-browser": "3.609.0",
-				"@aws-sdk/util-user-agent-node": "3.614.0",
-				"@smithy/config-resolver": "^3.0.5",
-				"@smithy/core": "^2.3.1",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/hash-node": "^3.0.3",
-				"@smithy/invalid-dependency": "^3.0.3",
-				"@smithy/middleware-content-length": "^3.0.5",
-				"@smithy/middleware-endpoint": "^3.1.0",
-				"@smithy/middleware-retry": "^3.0.13",
-				"@smithy/middleware-serde": "^3.0.3",
-				"@smithy/middleware-stack": "^3.0.3",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/url-parser": "^3.0.3",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
 				"@smithy/util-body-length-node": "^3.0.0",
-				"@smithy/util-defaults-mode-browser": "^3.0.13",
-				"@smithy/util-defaults-mode-node": "^3.0.13",
-				"@smithy/util-endpoints": "^2.0.5",
-				"@smithy/util-middleware": "^3.0.3",
-				"@smithy/util-retry": "^3.0.3",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -2152,18 +11309,20 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/core": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.621.0.tgz",
-			"integrity": "sha512-CtOwWmDdEiINkGXD93iGfXjN0WmCp9l45cDWHHGa8lRgEDyhuL7bwd/pH5aSzj0j8SiQBG2k0S7DHbd5RaqvbQ==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/core": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
+			"integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==",
 			"dependencies": {
-				"@smithy/core": "^2.3.1",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/signature-v4": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/util-middleware": "^3.0.3",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
 				"fast-xml-parser": "4.4.1",
 				"tslib": "^2.6.2"
 			},
@@ -2171,269 +11330,278 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.620.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
-			"integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.667.0.tgz",
+			"integrity": "sha512-zZbrkkaPc54WXm+QAnpuv0LPNfsts0HPPd+oCECGs7IQRaFsGj187cwvPg9RMWDFZqpm64MdBDoA8OQHsqzYCw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.621.0.tgz",
-			"integrity": "sha512-/jc2tEsdkT1QQAI5Dvoci50DbSxtJrevemwFsm0B73pwCcOQZ5ZwwSdVqGsPutzYzUVx3bcXg3LRL7jLACqRIg==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.667.0.tgz",
+			"integrity": "sha512-sjtybFfERZWiqTY7fswBxKQLvUkiCucOWyqh3IaPo/4nE1PXRnaZCVG0+kRBPrYIxWqiVwytvZzMJy8sVZcG0A==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/fetch-http-handler": "^3.2.4",
-				"@smithy/node-http-handler": "^3.1.4",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/smithy-client": "^3.1.11",
-				"@smithy/types": "^3.3.0",
-				"@smithy/util-stream": "^3.1.3",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-stream": "^3.1.9",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.621.0.tgz",
-			"integrity": "sha512-0EWVnSc+JQn5HLnF5Xv405M8n4zfdx9gyGdpnCmAmFqEDHA8LmBdxJdpUk1Ovp/I5oPANhjojxabIW5f1uU0RA==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.667.0.tgz",
+			"integrity": "sha512-NiEC2Sjut57ajbWEXLFtA8YWA06ulfuaSHOP4YxoQEsL3BjMOkKS1/5eVW2o6XkKVbwt0zbDYSTlIxU5klHpbQ==",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.620.1",
-				"@aws-sdk/credential-provider-http": "3.621.0",
-				"@aws-sdk/credential-provider-process": "3.620.1",
-				"@aws-sdk/credential-provider-sso": "3.621.0",
-				"@aws-sdk/credential-provider-web-identity": "3.621.0",
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/credential-provider-imds": "^3.2.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			},
-			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.621.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.621.0.tgz",
-			"integrity": "sha512-4JqpccUgz5Snanpt2+53hbOBbJQrSFq7E1sAAbgY6BKVQUsW5qyXqnjvSF32kDeKa5JpBl3bBWLZl04IadcPHw==",
-			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.620.1",
-				"@aws-sdk/credential-provider-http": "3.621.0",
-				"@aws-sdk/credential-provider-ini": "3.621.0",
-				"@aws-sdk/credential-provider-process": "3.620.1",
-				"@aws-sdk/credential-provider-sso": "3.621.0",
-				"@aws-sdk/credential-provider-web-identity": "3.621.0",
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/credential-provider-imds": "^3.2.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.620.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
-			"integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.621.0.tgz",
-			"integrity": "sha512-Kza0jcFeA/GEL6xJlzR2KFf1PfZKMFnxfGzJzl5yN7EjoGdMijl34KaRyVnfRjnCWcsUpBWKNIDk9WZVMY9yiw==",
-			"dependencies": {
-				"@aws-sdk/client-sso": "3.621.0",
-				"@aws-sdk/token-providers": "3.614.0",
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.621.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
-			"integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
-			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sts": "^3.621.0"
+				"@aws-sdk/client-sts": "^3.667.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.620.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
-			"integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.667.0.tgz",
+			"integrity": "sha512-+2oNexDvbQD9o5Xdtu1mGE25Nf2/C9KgMnkZzenbgCegw0P0YRdGrJklDF5Aag6lmb80a2vjoViuvm1ORzRAzw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-ini": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.609.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
-			"integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.667.0.tgz",
+			"integrity": "sha512-HZHnvop32fKgsNHkdhVaul7UzQ25sEc0j9yqA4bjhtbk0ECl42kj3f1pJ+ZU/YD9ut8lMJs/vVqiOdNThVdeBw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.620.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
-			"integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.667.0.tgz",
+			"integrity": "sha512-GylJquSQVWlziaEmrX38KzQTWcFL5NKht4OAj7rdo75MssC0qNVSGT+ReFrXZzKQ65eIuRVCMdsp83oNH4nzbQ==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/client-sso": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/token-providers": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.620.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz",
-			"integrity": "sha512-bvS6etn+KsuL32ubY5D3xNof1qkenpbJXf/ugGXbg0n98DvDFQ/F+SMLxHgbnER5dsKYchNnhmtI6/FC3HFu/A==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.667.0.tgz",
+			"integrity": "sha512-t8CFlZMD/1p/8Cli3rvRiTJpjr/8BO64gw166AHgFZYSN2h95L2l1tcW0jpsc3PprA32nLg1iQVKYt4WGM4ugw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@aws-sdk/util-endpoints": "3.614.0",
-				"@smithy/protocol-http": "^4.1.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.667.0.tgz",
+			"integrity": "sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
-			"integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.667.0.tgz",
+			"integrity": "sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.667.0.tgz",
+			"integrity": "sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.667.0.tgz",
+			"integrity": "sha512-NJoPMV+9hpN90iZ2SgOpFmY6MJW71gGyT28kt0C68B0tBadYpT/J6WW8J7gxwdLA7d2CBwHbFGphTPWXXl+jzw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+			"integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-config-provider": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.3",
+				"@smithy/util-middleware": "^3.0.7",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/token-providers": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
-			"integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/token-providers": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.667.0.tgz",
+			"integrity": "sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/property-provider": "^3.1.3",
-				"@smithy/shared-ini-file-loader": "^3.1.4",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-sso-oidc": "^3.614.0"
+				"@aws-sdk/client-sso-oidc": "^3.667.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/types": {
-			"version": "3.609.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-			"integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
 			"dependencies": {
-				"@smithy/types": "^3.3.0",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
-			"integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.667.0.tgz",
+			"integrity": "sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/types": "^3.3.0",
-				"@smithy/util-endpoints": "^2.0.5",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-endpoints": "^2.1.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.609.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
-			"integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.667.0.tgz",
+			"integrity": "sha512-y1pKlNzNpxzddM0QSnfIfIbi3Z9LTag1VDjYyZRbEGGSVip2J00qKsET+979nRezWMyJgw5GPBQR3Y+rN+jh0Q==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.614.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
-			"integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.667.0.tgz",
+			"integrity": "sha512-4OcWyWUAYRLwXMxqUqnDb/3LoassXvEJcwjiIKEa7p0JvtSa9VjCL6B8Vjw8C/N6YoqrlFEEvcN7SlwBEy74pA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.609.0",
-				"@smithy/node-config-provider": "^3.1.4",
-				"@smithy/types": "^3.3.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2448,16 +11616,16 @@
 				}
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@smithy/signature-v4": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.4.tgz",
-			"integrity": "sha512-72MiK7xYukNsnLJI9NqvUHqTu0ziEsfMsYNlWpiJfuGQnCTFKpckThlEatirvcA/LmT1h7rRO+pJD06PYsPu9Q==",
+		"node_modules/@aws-sdk/client-ssm/node_modules/@smithy/signature-v4": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
+			"integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^3.0.0",
-				"@smithy/protocol-http": "^4.1.3",
-				"@smithy/types": "^3.4.2",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-hex-encoding": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.6",
+				"@smithy/util-middleware": "^3.0.7",
 				"@smithy/util-uri-escape": "^3.0.0",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
@@ -2466,18 +11634,7 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@smithy/util-buffer-from": {
+		"node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-buffer-from": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
 			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
@@ -2489,7 +11646,7 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+		"node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
 			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
@@ -2500,7 +11657,7 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-personalize-events/node_modules/fast-xml-parser": {
+		"node_modules/@aws-sdk/client-ssm/node_modules/fast-xml-parser": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
 			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
@@ -2686,6 +11843,33 @@
 				"node": ">=16.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.667.0.tgz",
+			"integrity": "sha512-+aE/LZXAdCGpMKREus959oJNwXYx2igSP4VCiQMWr245497SbvzSep4ZRtq6GpG71aACviN2BwCyh+1u60Yb/A==",
+			"dependencies": {
+				"@aws-sdk/client-cognito-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/@aws-sdk/credential-provider-env": {
 			"version": "3.577.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.577.0.tgz",
@@ -2813,6 +11997,769 @@
 				"@aws-sdk/client-sts": "^3.577.0"
 			}
 		},
+		"node_modules/@aws-sdk/credential-providers": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.667.0.tgz",
+			"integrity": "sha512-paoSF3GPJ7oAkRzDlgicykrIZvgmB62E3qJWIUFyC/dkK3QkipbFjzFgoPeV46oNqXevFfGdCnu8lCSKNmdSFg==",
+			"dependencies": {
+				"@aws-sdk/client-cognito-identity": "3.667.0",
+				"@aws-sdk/client-sso": "3.667.0",
+				"@aws-sdk/client-sts": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.667.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-ini": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.667.0.tgz",
+			"integrity": "sha512-69nl3BXcAfn/zUdxpxC/5Bi4K46sMgTRFVKHkyiRFO8OQpNJDRzl6eGltESLqtf65rjWfswTDwfYrMd2+tnlDQ==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.667.0.tgz",
+			"integrity": "sha512-ThLLR0Zn15Rk8Y6rzzVtHREZU4NAsNj9oCiQcXj4/vlBl+J0MbiTCDUJTc559O+DIMekrjusLaPIKfTZmXXuhA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.667.0.tgz",
+			"integrity": "sha512-SnvkDDuOAwXOxzhGfvvxK8JFFVApVvXrM6+nVmSYwuHjWdI+HwNcsRC6rxZ8uHQEz2fR0a810ckUwFVfpvtIoA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/client-sso-oidc": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-node": "3.667.0",
+				"@aws-sdk/middleware-host-header": "3.667.0",
+				"@aws-sdk/middleware-logger": "3.667.0",
+				"@aws-sdk/middleware-recursion-detection": "3.667.0",
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/region-config-resolver": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@aws-sdk/util-user-agent-browser": "3.667.0",
+				"@aws-sdk/util-user-agent-node": "3.667.0",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/core": "^2.4.8",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/hash-node": "^3.0.7",
+				"@smithy/invalid-dependency": "^3.0.7",
+				"@smithy/middleware-content-length": "^3.0.9",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-base64": "^3.0.0",
+				"@smithy/util-body-length-browser": "^3.0.0",
+				"@smithy/util-body-length-node": "^3.0.0",
+				"@smithy/util-defaults-mode-browser": "^3.0.23",
+				"@smithy/util-defaults-mode-node": "^3.0.23",
+				"@smithy/util-endpoints": "^2.1.3",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/core": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
+			"integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.667.0.tgz",
+			"integrity": "sha512-zZbrkkaPc54WXm+QAnpuv0LPNfsts0HPPd+oCECGs7IQRaFsGj187cwvPg9RMWDFZqpm64MdBDoA8OQHsqzYCw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.667.0.tgz",
+			"integrity": "sha512-sjtybFfERZWiqTY7fswBxKQLvUkiCucOWyqh3IaPo/4nE1PXRnaZCVG0+kRBPrYIxWqiVwytvZzMJy8sVZcG0A==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-stream": "^3.1.9",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.667.0.tgz",
+			"integrity": "sha512-NiEC2Sjut57ajbWEXLFtA8YWA06ulfuaSHOP4YxoQEsL3BjMOkKS1/5eVW2o6XkKVbwt0zbDYSTlIxU5klHpbQ==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.667.0.tgz",
+			"integrity": "sha512-+2oNexDvbQD9o5Xdtu1mGE25Nf2/C9KgMnkZzenbgCegw0P0YRdGrJklDF5Aag6lmb80a2vjoViuvm1ORzRAzw==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.667.0",
+				"@aws-sdk/credential-provider-http": "3.667.0",
+				"@aws-sdk/credential-provider-ini": "3.667.0",
+				"@aws-sdk/credential-provider-process": "3.667.0",
+				"@aws-sdk/credential-provider-sso": "3.667.0",
+				"@aws-sdk/credential-provider-web-identity": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.667.0.tgz",
+			"integrity": "sha512-HZHnvop32fKgsNHkdhVaul7UzQ25sEc0j9yqA4bjhtbk0ECl42kj3f1pJ+ZU/YD9ut8lMJs/vVqiOdNThVdeBw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.667.0.tgz",
+			"integrity": "sha512-GylJquSQVWlziaEmrX38KzQTWcFL5NKht4OAj7rdo75MssC0qNVSGT+ReFrXZzKQ65eIuRVCMdsp83oNH4nzbQ==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.667.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/token-providers": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.667.0.tgz",
+			"integrity": "sha512-t8CFlZMD/1p/8Cli3rvRiTJpjr/8BO64gw166AHgFZYSN2h95L2l1tcW0jpsc3PprA32nLg1iQVKYt4WGM4ugw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sts": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.667.0.tgz",
+			"integrity": "sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.667.0.tgz",
+			"integrity": "sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.667.0.tgz",
+			"integrity": "sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.667.0.tgz",
+			"integrity": "sha512-NJoPMV+9hpN90iZ2SgOpFmY6MJW71gGyT28kt0C68B0tBadYpT/J6WW8J7gxwdLA7d2CBwHbFGphTPWXXl+jzw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-endpoints": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+			"integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.667.0.tgz",
+			"integrity": "sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-sso-oidc": "^3.667.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.667.0.tgz",
+			"integrity": "sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-endpoints": "^2.1.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.667.0.tgz",
+			"integrity": "sha512-y1pKlNzNpxzddM0QSnfIfIbi3Z9LTag1VDjYyZRbEGGSVip2J00qKsET+979nRezWMyJgw5GPBQR3Y+rN+jh0Q==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.667.0.tgz",
+			"integrity": "sha512-4OcWyWUAYRLwXMxqUqnDb/3LoassXvEJcwjiIKEa7p0JvtSa9VjCL6B8Vjw8C/N6YoqrlFEEvcN7SlwBEy74pA==",
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@smithy/signature-v4": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
+			"integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers/node_modules/fast-xml-parser": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
+				}
+			],
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-bucket-endpoint": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.667.0.tgz",
+			"integrity": "sha512-XGz4jMAkDoTyFdtLz7ZF+C05IAhCTC1PllpvTBaj821z/L0ilhbqVhrT/f2Buw8Id/K5A390csGXgusXyrFFjA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-arn-parser": "3.568.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-expect-continue": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.667.0.tgz",
+			"integrity": "sha512-0TiSL9S5DSG95NHGIz6qTMuV7GDKVn8tvvGSrSSZu/wXO3JaYSH0AElVpYfc4PtPRqVpEyNA7nnc7W56mMCLWQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-flexible-checksums": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.667.0.tgz",
+			"integrity": "sha512-+5B2JuN+/CGZk5HRD9GeeNyTy9ooVFxdnuIAHkDyokJ028/isWw02tcM0rIcI/zK/maV3Z1WXDtkvWKTfB2IqQ==",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@aws-crypto/crc32c": "5.2.0",
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/core": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
+			"integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/signature-v4": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
+			"integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/fast-xml-parser": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
+				}
+			],
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
 		"node_modules/@aws-sdk/middleware-host-header": {
 			"version": "3.577.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.577.0.tgz",
@@ -2821,6 +12768,31 @@
 				"@aws-sdk/types": "3.577.0",
 				"@smithy/protocol-http": "^4.0.0",
 				"@smithy/types": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-location-constraint": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.667.0.tgz",
+			"integrity": "sha512-ob85H3HhT3/u5O+x0o557xGZ78vSNeSSwMaSitxdsfs2hOuoUl1uk+OeLpi1hkuJnL41FPpokV7TVII2XrFfmg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2848,6 +12820,127 @@
 				"@aws-sdk/types": "3.577.0",
 				"@smithy/protocol-http": "^4.0.0",
 				"@smithy/types": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-s3": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.667.0.tgz",
+			"integrity": "sha512-31SqWDEH340kwRyql6II4wgVTNa2GJypIry5bmEzuSR30tsuWnVQg8y7zgUCDanph2GnlIFp6U+vqC9R8kDRmw==",
+			"dependencies": {
+				"@aws-sdk/core": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@aws-sdk/util-arn-parser": "3.568.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-config-provider": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-stream": "^3.1.9",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
+			"integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/core": "^2.4.8",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/signature-v4": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
+			"integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-s3/node_modules/fast-xml-parser": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
+				}
+			],
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-ssec": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.667.0.tgz",
+			"integrity": "sha512-1wuAUZIkmZIvOmGg5qNQU821CGFHhkuKioxXgNh0DpUxZ9+AeiV7yorJr+bqkb2KBFv1i1TnzGRecvKf/KvZIQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2885,6 +12978,52 @@
 				"node": ">=16.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.667.0.tgz",
+			"integrity": "sha512-9HBgapQOvrb3qvZfPcIY41D3YRNfcOuyIKqZ3h9FYbM06qOZXmIN7Y8bYL31ANGR3Mce6yu3mcnaqvrC/j1Q1w==",
+			"dependencies": {
+				"@aws-sdk/middleware-sdk-s3": "3.667.0",
+				"@aws-sdk/types": "3.667.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/signature-v4": "^4.2.0",
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+			"version": "3.667.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+			"integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/signature-v4": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
+			"integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^3.0.0",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-hex-encoding": "^3.0.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-uri-escape": "^3.0.0",
+				"@smithy/util-utf8": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/@aws-sdk/token-providers": {
 			"version": "3.577.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.577.0.tgz",
@@ -2909,6 +13048,17 @@
 			"integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
 			"dependencies": {
 				"@smithy/types": "^3.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-arn-parser": {
+			"version": "3.568.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.568.0.tgz",
+			"integrity": "sha512-XUKJWWo+KOB7fbnPP0+g/o5Ulku/X53t7i/h+sPHr5xxYTJJ9CYnbToo95mzxe7xWvkLrsNtJ8L+MnNn9INs2w==",
+			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2981,11 +13131,22 @@
 				"tslib": "^2.3.1"
 			}
 		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.662.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.662.0.tgz",
+			"integrity": "sha512-ikLkXn0igUpnJu2mCZjklvmcDGWT9OaLRv3JyC/cRkTaaSrblPjPM7KKsltxdMTLQ+v7fjCN0TsJpxphMfaOPA==",
+			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
 			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/highlight": "^7.24.7",
 				"picocolors": "^1.0.0"
@@ -2998,7 +13159,6 @@
 			"version": "7.25.4",
 			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
 			"integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -3007,7 +13167,6 @@
 			"version": "7.25.2",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
 			"integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
-			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.24.7",
@@ -3037,7 +13196,6 @@
 			"version": "4.3.5",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
 			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -3053,14 +13211,12 @@
 		"node_modules/@babel/core/node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/@babel/core/node_modules/semver": {
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -3069,7 +13225,6 @@
 			"version": "7.25.6",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
 			"integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
-			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.25.6",
 				"@jridgewell/gen-mapping": "^0.3.5",
@@ -3084,7 +13239,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
 			"integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.24.7"
 			},
@@ -3109,7 +13263,6 @@
 			"version": "7.25.2",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
 			"integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
-			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.25.2",
 				"@babel/helper-validator-option": "^7.24.8",
@@ -3125,7 +13278,6 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"dev": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
 			}
@@ -3134,7 +13286,6 @@
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -3143,7 +13294,6 @@
 			"version": "7.25.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
 			"integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
 				"@babel/helper-member-expression-to-functions": "^7.24.8",
@@ -3164,7 +13314,6 @@
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -3238,7 +13387,6 @@
 			"version": "7.24.8",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
 			"integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/traverse": "^7.24.8",
 				"@babel/types": "^7.24.8"
@@ -3251,7 +13399,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
 			"integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/traverse": "^7.24.7",
 				"@babel/types": "^7.24.7"
@@ -3264,7 +13411,6 @@
 			"version": "7.25.2",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
 			"integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.24.7",
 				"@babel/helper-simple-access": "^7.24.7",
@@ -3282,7 +13428,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
 			"integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
-			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.24.7"
 			},
@@ -3291,10 +13436,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
-			"integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
-			"dev": true,
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.7.tgz",
+			"integrity": "sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -3320,7 +13464,6 @@
 			"version": "7.25.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
 			"integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-member-expression-to-functions": "^7.24.8",
 				"@babel/helper-optimise-call-expression": "^7.24.7",
@@ -3337,7 +13480,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
 			"integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/traverse": "^7.24.7",
 				"@babel/types": "^7.24.7"
@@ -3350,7 +13492,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
 			"integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/traverse": "^7.24.7",
 				"@babel/types": "^7.24.7"
@@ -3363,7 +13504,6 @@
 			"version": "7.24.8",
 			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
 			"integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -3372,7 +13512,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
 			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -3381,7 +13520,6 @@
 			"version": "7.24.8",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
 			"integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -3404,7 +13542,6 @@
 			"version": "7.25.6",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
 			"integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
-			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.25.0",
 				"@babel/types": "^7.25.6"
@@ -3417,7 +13554,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
 			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.24.7",
 				"chalk": "^2.4.2",
@@ -3432,7 +13568,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -3444,7 +13579,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -3458,7 +13592,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
@@ -3466,14 +13599,12 @@
 		"node_modules/@babel/highlight/node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 		},
 		"node_modules/@babel/highlight/node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -3482,7 +13613,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -3494,7 +13624,6 @@
 			"version": "7.25.6",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
 			"integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
-			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.25.6"
 			},
@@ -3584,6 +13713,41 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
+		"node_modules/@babel/plugin-proposal-class-properties": {
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+			"integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
+			"deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^7.18.6",
+				"@babel/helper-plugin-utils": "^7.18.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.20.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
+			"integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
+			"deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
+			"dependencies": {
+				"@babel/compat-data": "^7.20.5",
+				"@babel/helper-compilation-targets": "^7.20.7",
+				"@babel/helper-plugin-utils": "^7.20.2",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-transform-parameters": "^7.20.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
 		"node_modules/@babel/plugin-proposal-private-property-in-object": {
 			"version": "7.21.0-placeholder-for-preset-env.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
@@ -3612,7 +13776,6 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
 			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.12.13"
 			},
@@ -3654,6 +13817,20 @@
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.3"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-flow": {
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.25.7.tgz",
+			"integrity": "sha512-fyoj6/YdVtlv2ROig/J0fP7hh/wNO1MJGm1NR70Pg7jbkF+jOUL9joorqaCOQh06Y+LfgTagHzC8KqZ3MF782w==",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -3717,7 +13894,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
 			"integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7"
 			},
@@ -3768,7 +13944,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
 			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -3850,7 +14025,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.7.tgz",
 			"integrity": "sha512-Dt9LQs6iEY++gXUwY03DNFat5C2NbO48jj+j/bSAz6b3HgPs39qcPiYt77fDObIcFwj3/C2ICX9YMwGflUoSHQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7"
 			},
@@ -3900,7 +14074,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.7.tgz",
 			"integrity": "sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7"
 			},
@@ -3915,7 +14088,6 @@
 			"version": "7.25.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.0.tgz",
 			"integrity": "sha512-yBQjYoOjXlFv9nlXb3f1casSHOZkWr29NX+zChVanLg5Nc157CrbEX9D7hxxtTpuFy7Q0YzmmWfJxzvps4kXrQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.8"
 			},
@@ -3963,7 +14135,6 @@
 			"version": "7.25.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.4.tgz",
 			"integrity": "sha512-oexUfaQle2pF/b6E0dwsxQtAol9TLSO88kQvym6HHBWFliV2lGdrPieX+WgMRLSJDVzdYywk7jXbLPuO2KLTLg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
 				"@babel/helper-compilation-targets": "^7.25.2",
@@ -3983,7 +14154,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.7.tgz",
 			"integrity": "sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/template": "^7.24.7"
@@ -3999,7 +14169,6 @@
 			"version": "7.24.8",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.8.tgz",
 			"integrity": "sha512-36e87mfY8TnRxc7yc6M9g9gOB7rKgSahqkIKwLpz4Ppk2+zC2Cy1is0uwtuSG6AE4zlTOUa+7JGz9jCJGLqQFQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.8"
 			},
@@ -4105,11 +14274,25 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
+		"node_modules/@babel/plugin-transform-flow-strip-types": {
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.7.tgz",
+			"integrity": "sha512-q8Td2PPc6/6I73g96SreSUCKEcwMXCwcXSIAVTyTTN6CpJe0dMj8coxu1fg1T9vfBLi6Rsi6a4ECcFBbKabS5w==",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.7",
+				"@babel/plugin-syntax-flow": "^7.25.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
 		"node_modules/@babel/plugin-transform-for-of": {
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.7.tgz",
 			"integrity": "sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
@@ -4125,7 +14308,6 @@
 			"version": "7.25.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.1.tgz",
 			"integrity": "sha512-TVVJVdW9RKMNgJJlLtHsKDTydjZAbwIsn6ySBPQaEAUU5+gVvlJt/9nRmqVbsV/IBanRjzWoaAQKLoamWVOUuA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.24.8",
 				"@babel/helper-plugin-utils": "^7.24.8",
@@ -4158,7 +14340,6 @@
 			"version": "7.25.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.2.tgz",
 			"integrity": "sha512-HQI+HcTbm9ur3Z2DkO+jgESMAMcYLuN/A7NRw9juzxAezN9AvqvUTnpKP/9kkYANz6u7dFlAyOu44ejuGySlfw==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.8"
 			},
@@ -4189,7 +14370,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.7.tgz",
 			"integrity": "sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7"
 			},
@@ -4220,7 +14400,6 @@
 			"version": "7.24.8",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
 			"integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-transforms": "^7.24.8",
 				"@babel/helper-plugin-utils": "^7.24.8",
@@ -4352,7 +14531,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.7.tgz",
 			"integrity": "sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/helper-replace-supers": "^7.24.7"
@@ -4401,7 +14579,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.7.tgz",
 			"integrity": "sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7"
 			},
@@ -4450,7 +14627,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.7.tgz",
 			"integrity": "sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7"
 			},
@@ -4465,7 +14641,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.7.tgz",
 			"integrity": "sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7"
 			},
@@ -4480,7 +14655,6 @@
 			"version": "7.25.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.2.tgz",
 			"integrity": "sha512-KQsqEAVBpU82NM/B/N9j9WOdphom1SZH3R+2V7INrQUH+V9EBFwZsEJl8eBIVeQE62FxJCc70jzEZwqU7RcVqA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
 				"@babel/helper-module-imports": "^7.24.7",
@@ -4561,7 +14735,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.7.tgz",
 			"integrity": "sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7"
 			},
@@ -4576,7 +14749,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.7.tgz",
 			"integrity": "sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
@@ -4607,7 +14779,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.7.tgz",
 			"integrity": "sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7"
 			},
@@ -4857,7 +15028,6 @@
 			"version": "7.25.0",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
 			"integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
-			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
 				"@babel/parser": "^7.25.0",
@@ -4871,7 +15041,6 @@
 			"version": "7.25.6",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
 			"integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
 				"@babel/generator": "^7.25.6",
@@ -4889,7 +15058,6 @@
 			"version": "4.3.5",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
 			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -4905,14 +15073,12 @@
 		"node_modules/@babel/traverse/node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/@babel/types": {
 			"version": "7.25.6",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
 			"integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.24.8",
 				"@babel/helper-validator-identifier": "^7.24.7",
@@ -4998,6 +15164,301 @@
 			"peerDependencies": {
 				"@fortawesome/fontawesome-svg-core": "~1 || ~6",
 				"react": ">=16.3"
+			}
+		},
+		"node_modules/@graphql-codegen/core": {
+			"version": "2.6.8",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-2.6.8.tgz",
+			"integrity": "sha512-JKllNIipPrheRgl+/Hm/xuWMw9++xNQ12XJR/OHHgFopOg4zmN3TdlRSyYcv/K90hCFkkIwhlHFUQTfKrm8rxQ==",
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^3.1.1",
+				"@graphql-tools/schema": "^9.0.0",
+				"@graphql-tools/utils": "^9.1.1",
+				"tslib": "~2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/core/node_modules/@graphql-codegen/plugin-helpers": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
+			"integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
+			"dependencies": {
+				"@graphql-tools/utils": "^9.0.0",
+				"change-case-all": "1.0.15",
+				"common-tags": "1.8.2",
+				"import-from": "4.0.0",
+				"lodash": "~4.17.0",
+				"tslib": "~2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/core/node_modules/@graphql-tools/utils": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+			"integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/core/node_modules/change-case-all": {
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
+			"integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
+			"dependencies": {
+				"change-case": "^4.1.2",
+				"is-lower-case": "^2.0.2",
+				"is-upper-case": "^2.0.2",
+				"lower-case": "^2.0.2",
+				"lower-case-first": "^2.0.2",
+				"sponge-case": "^1.0.1",
+				"swap-case": "^2.0.2",
+				"title-case": "^3.0.3",
+				"upper-case": "^2.0.2",
+				"upper-case-first": "^2.0.2"
+			}
+		},
+		"node_modules/@graphql-codegen/core/node_modules/tslib": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+		},
+		"node_modules/@graphql-codegen/plugin-helpers": {
+			"version": "1.18.8",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.18.8.tgz",
+			"integrity": "sha512-mb4I9j9lMGqvGggYuZ0CV+Hme08nar68xkpPbAVotg/ZBmlhZIok/HqW2BcMQi7Rj+Il5HQMeQ1wQ1M7sv/TlQ==",
+			"dependencies": {
+				"@graphql-tools/utils": "^7.9.1",
+				"common-tags": "1.8.0",
+				"import-from": "4.0.0",
+				"lodash": "~4.17.0",
+				"tslib": "~2.3.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/plugin-helpers/node_modules/@graphql-tools/utils": {
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.10.0.tgz",
+			"integrity": "sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==",
+			"dependencies": {
+				"@ardatan/aggregate-error": "0.0.6",
+				"camel-case": "4.1.2",
+				"tslib": "~2.2.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/plugin-helpers/node_modules/@graphql-tools/utils/node_modules/tslib": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+			"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+		},
+		"node_modules/@graphql-codegen/plugin-helpers/node_modules/common-tags": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+		},
+		"node_modules/@graphql-codegen/visitor-plugin-common": {
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.22.0.tgz",
+			"integrity": "sha512-2afJGb6d8iuZl9KizYsexPwraEKO1lAvt5eVHNM5Xew4vwz/AUHeqDR2uOeQgVV+27EzjjzSDd47IEdH0dLC2w==",
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^1.18.8",
+				"@graphql-tools/optimize": "^1.0.1",
+				"@graphql-tools/relay-operation-optimizer": "^6.3.0",
+				"array.prototype.flatmap": "^1.2.4",
+				"auto-bind": "~4.0.0",
+				"change-case-all": "1.0.14",
+				"dependency-graph": "^0.11.0",
+				"graphql-tag": "^2.11.0",
+				"parse-filepath": "^1.0.2",
+				"tslib": "~2.3.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+		},
+		"node_modules/@graphql-tools/apollo-engine-loader": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.1.tgz",
+			"integrity": "sha512-NaPeVjtrfbPXcl+MLQCJLWtqe2/E4bbAqcauEOQ+3sizw1Fc2CNmhHRF8a6W4D0ekvTRRXAMptXYgA2uConbrA==",
+			"dependencies": {
+				"@ardatan/sync-fetch": "^0.0.1",
+				"@graphql-tools/utils": "^10.0.13",
+				"@whatwg-node/fetch": "^0.9.0",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/apollo-engine-loader/node_modules/@graphql-tools/utils": {
+			"version": "10.5.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
+			"integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"cross-inspect": "1.0.1",
+				"dset": "^3.1.2",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/merge": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
+			"integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+			"dependencies": {
+				"@graphql-tools/utils": "^9.2.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+			"integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/optimize": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.4.0.tgz",
+			"integrity": "sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==",
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/relay-operation-optimizer": {
+			"version": "6.5.18",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz",
+			"integrity": "sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==",
+			"dependencies": {
+				"@ardatan/relay-compiler": "12.0.0",
+				"@graphql-tools/utils": "^9.2.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/relay-operation-optimizer/node_modules/@graphql-tools/utils": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+			"integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/schema": {
+			"version": "9.0.19",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
+			"integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+			"dependencies": {
+				"@graphql-tools/merge": "^8.4.1",
+				"@graphql-tools/utils": "^9.2.1",
+				"tslib": "^2.4.0",
+				"value-or-promise": "^1.0.12"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+			"integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/utils": {
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-6.2.4.tgz",
+			"integrity": "sha512-ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==",
+			"dependencies": {
+				"@ardatan/aggregate-error": "0.0.6",
+				"camel-case": "4.1.1",
+				"tslib": "~2.0.1"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/utils/node_modules/camel-case": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+			"integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+			"dependencies": {
+				"pascal-case": "^3.1.1",
+				"tslib": "^1.10.0"
+			}
+		},
+		"node_modules/@graphql-tools/utils/node_modules/camel-case/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@graphql-tools/utils/node_modules/tslib": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+			"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+		},
+		"node_modules/@graphql-typed-document-node/core": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+			"integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@isaacs/cliui": {
@@ -5581,6 +16042,11 @@
 				"tslib": "2"
 			}
 		},
+		"node_modules/@kamilkisiela/fast-url-parser": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz",
+			"integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew=="
+		},
 		"node_modules/@leichtgewicht/ip-codec": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -5785,48 +16251,43 @@
 			}
 		},
 		"node_modules/@smithy/abort-controller": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.4.tgz",
-			"integrity": "sha512-VupaALAQlXViW3/enTf/f5l5JZYSAxoJL7f0nanhNNKnww6DGCg1oYIuNP78KDugnkwthBO6iEcym16HhWV8RQ==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.5.tgz",
+			"integrity": "sha512-DhNPnqTqPoG8aZ5dWkFOgsuY+i0GQ3CI6hMmvCoduNsnU9gUZWZBwGfDQsTTB7NvFPkom1df7jMIJWU90kuXXg==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
+		"node_modules/@smithy/chunked-blob-reader": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-3.0.0.tgz",
+			"integrity": "sha512-sbnURCwjF0gSToGlsBiAmd1lRCmSn72nu9axfJu5lIx6RUEgHu6GwTMbqCdhQSi0Pumcm5vFxsi9XWXb2mTaoA==",
 			"dependencies": {
 				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@smithy/chunked-blob-reader-native": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.0.tgz",
+			"integrity": "sha512-VDkpCYW+peSuM4zJip5WDfqvg2Mo/e8yxOv3VF1m11y7B8KKMKVFtmZWDe36Fvk8rGuWrPZHHXZ7rR7uM5yWyg==",
+			"dependencies": {
+				"@smithy/util-base64": "^3.0.0",
+				"tslib": "^2.6.2"
 			}
 		},
 		"node_modules/@smithy/config-resolver": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.8.tgz",
-			"integrity": "sha512-Tv1obAC18XOd2OnDAjSWmmthzx6Pdeh63FbLin8MlPiuJ2ATpKkq0NcNOJFr0dO+JmZXnwu8FQxKJ3TKJ3Hulw==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.9.tgz",
+			"integrity": "sha512-5d9oBf40qC7n2xUoHmntKLdqsyTMMo/r49+eqSIjJ73eDfEtljAxEhzIQ3bkgXJtR3xiv7YzMT/3FF3ORkjWdg==",
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.7",
-				"@smithy/types": "^3.4.2",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-config-provider": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.6",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/config-resolver/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/util-middleware": "^3.0.7",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5834,18 +16295,18 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.6.tgz",
-			"integrity": "sha512-6lQQp99hnyuNNIzeTYSzCUXJHwvvFLY7hfdFGSJM95tjRDJGfzWYFRBXPaM9766LiiTsQ561KErtbufzUFSYUg==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.8.tgz",
+			"integrity": "sha512-x4qWk7p/a4dcf7Vxb2MODIf4OIcqNbK182WxRvZ/3oKPrf/6Fdic5sSElhO1UtXpWKBazWfqg0ZEK9xN1DsuHA==",
 			"dependencies": {
-				"@smithy/middleware-endpoint": "^3.1.3",
-				"@smithy/middleware-retry": "^3.0.21",
-				"@smithy/middleware-serde": "^3.0.6",
-				"@smithy/protocol-http": "^4.1.3",
-				"@smithy/smithy-client": "^3.3.5",
-				"@smithy/types": "^3.4.2",
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-retry": "^3.0.23",
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-body-length-browser": "^3.0.0",
-				"@smithy/util-middleware": "^3.0.6",
+				"@smithy/util-middleware": "^3.0.7",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -5853,37 +16314,15 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@smithy/core/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.3.tgz",
-			"integrity": "sha512-VoxMzSzdvkkjMJNE38yQgx4CfnmT+Z+5EUXkg4x7yag93eQkVQgZvN3XBSHC/ylfBbLbAtdu7flTCChX9I+mVg==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.4.tgz",
+			"integrity": "sha512-S9bb0EIokfYEuar4kEbLta+ivlKCWOCFsLZuilkNy9i0uEUEHSi47IFLPaxqqCl+0ftKmcOTHayY5nQhAuq7+w==",
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.7",
-				"@smithy/property-provider": "^3.1.6",
-				"@smithy/types": "^3.4.2",
-				"@smithy/url-parser": "^3.0.6",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5891,45 +16330,23 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-codec": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.5.tgz",
-			"integrity": "sha512-6pu+PT2r+5ZnWEV3vLV1DzyrpJ0TmehQlniIDCSpZg6+Ji2SfOI38EqUyQ+O8lotVElCrfVc9chKtSMe9cmCZQ==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.6.tgz",
+			"integrity": "sha512-SBiOYPBH+5wOyPS7lfI150ePfGLhnp/eTu5RnV9xvhGvRiKfnl6HzRK9wehBph+il8FxS9KTeadx7Rcmf1GLPQ==",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^3.4.2",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-hex-encoding": "^3.0.0",
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@smithy/eventstream-codec/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
 		"node_modules/@smithy/eventstream-serde-browser": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.9.tgz",
-			"integrity": "sha512-PiQLo6OQmZAotJweIcObL1H44gkvuJACKMNqpBBe5Rf2Ax1DOcGi/28+feZI7yTe1ERHlQQaGnm8sSkyDUgsMg==",
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.10.tgz",
+			"integrity": "sha512-1i9aMY6Pl/SmA6NjvidxnfBLHMPzhKu2BP148pEt5VwhMdmXn36PE2kWKGa9Hj8b0XGtCTRucpCncylevCtI7g==",
 			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^3.0.8",
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-browser/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^3.0.9",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5937,22 +16354,11 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-config-resolver": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.6.tgz",
-			"integrity": "sha512-iew15It+c7WfnVowWkt2a7cdPp533LFJnpjDQgfZQcxv2QiOcyEcea31mnrk5PVbgo0nNH3VbYGq7myw2q/F6A==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.7.tgz",
+			"integrity": "sha512-eVzhGQBPEqXXYHvIUku0jMTxd4gDvenRzUQPTmKVWdRvp9JUCKrbAXGQRYiGxUYq9+cqQckRm0wq3kTWnNtDhw==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-config-resolver/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5960,23 +16366,12 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-node": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.8.tgz",
-			"integrity": "sha512-6m+wI+fT0na+6oao6UqALVA38fsScCpoG5UO/A8ZSyGLnPM2i4MS1cFUhpuALgvLMxfYoTCh7qSeJa0aG4IWpQ==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.9.tgz",
+			"integrity": "sha512-JE0Guqvt0xsmfQ5y1EI342/qtJqznBv8cJqkHZV10PwC8GWGU5KNgFbQnsVCcX+xF+qIqwwfRmeWoJCjuOLmng==",
 			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^3.0.8",
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-node/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^3.0.9",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5984,23 +16379,12 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-universal": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.8.tgz",
-			"integrity": "sha512-09tqzIQ6e+7jLqGvRji1yJoDbL/zob0OFhq75edgStWErGLf16+yI5hRc/o9/YAybOhUZs/swpW2SPn892G5Gg==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.9.tgz",
+			"integrity": "sha512-bydfgSisfepCufw9kCEnWRxqxJFzX/o8ysXWv+W9F2FIyiaEwZ/D8bBKINbh4ONz3i05QJ1xE7A5OKYvgJsXaw==",
 			"dependencies": {
-				"@smithy/eventstream-codec": "^3.1.5",
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-universal/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/eventstream-codec": "^3.1.6",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6008,34 +16392,34 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "3.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.8.tgz",
-			"integrity": "sha512-Lqe0B8F5RM7zkw//6avq1SJ8AfaRd3ubFUS1eVp5WszV7p6Ne5hQ4dSuMHDpNRPhgTvj4va9Kd/pcVigHEHRow==",
+			"version": "3.2.9",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
+			"integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
 			"dependencies": {
-				"@smithy/protocol-http": "^4.1.3",
-				"@smithy/querystring-builder": "^3.0.6",
-				"@smithy/types": "^3.4.2",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/querystring-builder": "^3.0.7",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-base64": "^3.0.0",
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
+		"node_modules/@smithy/hash-blob-browser": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.6.tgz",
+			"integrity": "sha512-BKNcMIaeZ9lB67sgo88iCF4YB35KT8X2dNJ8DqrtZNTgN6tUDYBKThzfGtos/mnZkGkW91AYHisESHmSiYQmKw==",
 			"dependencies": {
+				"@smithy/chunked-blob-reader": "^3.0.0",
+				"@smithy/chunked-blob-reader-native": "^3.0.0",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@smithy/hash-node": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.6.tgz",
-			"integrity": "sha512-c/FHEdKK/7DU2z6ZE91L36ahyXWayR3B+FzELjnYq7wH5YqIseM24V+pWCS9kFn1Ln8OFGTf+pyYPiHZuX0s/Q==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.7.tgz",
+			"integrity": "sha512-SAGHN+QkrwcHFjfWzs/czX94ZEjPJ0CrWJS3M43WswDXVEuP4AVy9gJ3+AF6JQHZD13bojmuf/Ap/ItDeZ+Qfw==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-buffer-from": "^3.0.0",
 				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
@@ -6044,11 +16428,13 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@smithy/hash-node/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
+		"node_modules/@smithy/hash-stream-node": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.6.tgz",
+			"integrity": "sha512-sFSSt7cmCpFWZPfVx7k80Bgb1K2VJ27VmMxH8X+dDhp7Wv8IBgID4K2VK5ehMJROF8hQgcj4WywnkHIwX/xlwQ==",
 			"dependencies": {
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-utf8": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6056,23 +16442,12 @@
 			}
 		},
 		"node_modules/@smithy/invalid-dependency": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.6.tgz",
-			"integrity": "sha512-czM7Ioq3s8pIXht7oD+vmgy4Wfb4XavU/k/irO8NdXFFOx7YAlsCCcKOh/lJD1mJSYQqiR7NmpZ9JviryD/7AQ==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.7.tgz",
+			"integrity": "sha512-Bq00GsAhHeYSuZX8Kpu4sbI9agH2BNYnqUmmbTGWOhki9NVsWn2jFr896vvoTMH8KAjNX/ErC/8t5QHuEXG+IA==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@smithy/invalid-dependency/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@smithy/is-array-buffer": {
@@ -6086,80 +16461,13 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@smithy/md5-js": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.7.tgz",
-			"integrity": "sha512-2i2BpXF9pI5D1xekqUsgQ/ohv5+H//G9FlawJrkOJskV18PgJ8LiNbLiskMeYt07yAsSTZR7qtlcAaa/GQLWww==",
-			"dependencies": {
-				"@smithy/types": "^2.3.1",
-				"@smithy/util-utf8": "^2.0.0",
-				"tslib": "^2.5.0"
-			}
-		},
-		"node_modules/@smithy/md5-js/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@smithy/md5-js/node_modules/@smithy/types": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-			"integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@smithy/md5-js/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@smithy/md5-js/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/@smithy/middleware-content-length": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.8.tgz",
-			"integrity": "sha512-VuyszlSO49WKh3H9/kIO2kf07VUwGV80QRiaDxUfP8P8UKlokz381ETJvwLhwuypBYhLymCYyNhB3fLAGBX2og==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.9.tgz",
+			"integrity": "sha512-t97PidoGElF9hTtLCrof32wfWMqC5g2SEJNxaVH3NjlatuNGsdxXRYO/t+RPnxA15RpYiS0f+zG7FuE2DeGgjA==",
 			"dependencies": {
-				"@smithy/protocol-http": "^4.1.3",
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-content-length/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6167,27 +16475,16 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.3.tgz",
-			"integrity": "sha512-KeM/OrK8MVFUsoJsmCN0MZMVPjKKLudn13xpgwIMpGTYpA8QZB2Xq5tJ+RE6iu3A6NhOI4VajDTwBsm8pwwrhg==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.4.tgz",
+			"integrity": "sha512-/ChcVHekAyzUbyPRI8CzPPLj6y8QRAfJngWcLMgsWxKVzw/RzBV69mSOzJYDD3pRwushA1+5tHtPF8fjmzBnrQ==",
 			"dependencies": {
-				"@smithy/middleware-serde": "^3.0.6",
-				"@smithy/node-config-provider": "^3.1.7",
-				"@smithy/shared-ini-file-loader": "^3.1.7",
-				"@smithy/types": "^3.4.2",
-				"@smithy/url-parser": "^3.0.6",
-				"@smithy/util-middleware": "^3.0.6",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-endpoint/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/middleware-serde": "^3.0.7",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
+				"@smithy/url-parser": "^3.0.7",
+				"@smithy/util-middleware": "^3.0.7",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6195,17 +16492,17 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "3.0.21",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.21.tgz",
-			"integrity": "sha512-/h0fElV95LekVVEJuSw+aI11S1Y3zIUwBc6h9ZbUv43Gl2weXsbQwjLoet6j/Qtb0phfrSxS6pNg6FqgJOWZkA==",
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.23.tgz",
+			"integrity": "sha512-x9PbGXxkcXIpm6L26qRSCC+eaYcHwybRmqU8LO/WM2RRlW0g8lz6FIiKbKgGvHuoK3dLZRiQVSQJveiCzwnA5A==",
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.7",
-				"@smithy/protocol-http": "^4.1.3",
-				"@smithy/service-error-classification": "^3.0.6",
-				"@smithy/smithy-client": "^3.3.5",
-				"@smithy/types": "^3.4.2",
-				"@smithy/util-middleware": "^3.0.6",
-				"@smithy/util-retry": "^3.0.6",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/service-error-classification": "^3.0.7",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-middleware": "^3.0.7",
+				"@smithy/util-retry": "^3.0.7",
 				"tslib": "^2.6.2",
 				"uuid": "^9.0.1"
 			},
@@ -6213,34 +16510,12 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@smithy/middleware-retry/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.6.tgz",
-			"integrity": "sha512-KKTUSl1MzOM0MAjGbudeaVNtIDo+PpekTBkCNwvfZlKndodrnvRo+00USatiyLOc0ujjO9UydMRu3O9dYML7ag==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.7.tgz",
+			"integrity": "sha512-VytaagsQqtH2OugzVTq4qvjkLNbWehHfGcGr0JLJmlDRrNCeZoWkWsSOw1nhS/4hyUUWF/TLGGml4X/OnEep5g==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-serde/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6248,22 +16523,11 @@
 			}
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.6.tgz",
-			"integrity": "sha512-2c0eSYhTQ8xQqHMcRxLMpadFbTXg6Zla5l0mwNftFCZMQmuhI7EbAJMx6R5eqfuV3YbJ3QGyS3d5uSmrHV8Khg==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.7.tgz",
+			"integrity": "sha512-EyTbMCdqS1DoeQsO4gI7z2Gzq1MoRFAeS8GkFYIwbedB7Lp5zlLHJdg+56tllIIG5Hnf9ZWX48YKSHlsKvugGA==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-stack/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6271,24 +16535,13 @@
 			}
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.7.tgz",
-			"integrity": "sha512-g3mfnC3Oo8pOI0dYuPXLtdW1WGVb3bR2tkV21GNkm0ZvQjLTtamXAwCWt/FCb0HGvKt3gHHmF1XerG0ICfalOg==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.8.tgz",
+			"integrity": "sha512-E0rU0DglpeJn5ge64mk8wTGEXcQwmpUTY5Zr7IzTpDLmHKiIamINERNZYrPQjg58Ck236sEKSwRSHA4CwshU6Q==",
 			"dependencies": {
-				"@smithy/property-provider": "^3.1.6",
-				"@smithy/shared-ini-file-loader": "^3.1.7",
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/node-config-provider/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/shared-ini-file-loader": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6296,25 +16549,14 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.3.tgz",
-			"integrity": "sha512-/gcm5DJ3k1b1zEInzBGAZC8ntJ+jwrz1NcSIu+9dSXd1FfG0G6QgkDI40tt8/WYUbHtLyo8fEqtm2v29koWo/w==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.4.tgz",
+			"integrity": "sha512-49reY3+JgLMFNm7uTAKBWiKCA6XSvkNp9FqhVmusm2jpVnHORYFeFZ704LShtqWfjZW/nhX+7Iexyb6zQfXYIQ==",
 			"dependencies": {
-				"@smithy/abort-controller": "^3.1.4",
-				"@smithy/protocol-http": "^4.1.3",
-				"@smithy/querystring-builder": "^3.0.6",
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/abort-controller": "^3.1.5",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/querystring-builder": "^3.0.7",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6322,22 +16564,11 @@
 			}
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.6.tgz",
-			"integrity": "sha512-NK3y/T7Q/Bw+Z8vsVs9MYIQ5v7gOX7clyrXcwhhIBQhbPgRl6JDrZbusO9qWDhcEus75Tg+VCxtIRfo3H76fpw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.7.tgz",
+			"integrity": "sha512-QfzLi1GPMisY7bAM5hOUqBdGYnY5S2JAlr201pghksrQv139f8iiiMalXtjczIP5f6owxFn3MINLNUNvUkgtPw==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/property-provider/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6345,22 +16576,11 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.3.tgz",
-			"integrity": "sha512-GcbMmOYpH9iRqtC05RbRnc/0FssxSTHlmaNhYBTgSgNCYpdR3Kt88u5GAZTBmouzv+Zlj/VRv92J9ruuDeJuEw==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.4.tgz",
+			"integrity": "sha512-MlWK8eqj0JlpZBnWmjQLqmFp71Ug00P+m72/1xQB3YByXD4zZ+y9N4hYrR0EDmrUCZIkyATWHOXFgtavwGDTzQ==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/protocol-http/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6368,11 +16588,11 @@
 			}
 		},
 		"node_modules/@smithy/querystring-builder": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.6.tgz",
-			"integrity": "sha512-sQe08RunoObe+Usujn9+R2zrLuQERi3CWvRO3BvnoWSYUaIrLKuAIeY7cMeDax6xGyfIP3x/yFWbEKSXvOnvVg==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.7.tgz",
+			"integrity": "sha512-65RXGZZ20rzqqxTsChdqSpbhA6tdt5IFNgG6o7e1lnPVLCe6TNWQq4rTl4N87hTDD8mV4IxJJnvyE7brbnRkQw==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-uri-escape": "^3.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -6380,34 +16600,12 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.6.tgz",
-			"integrity": "sha512-UJKw4LlEkytzz2Wq+uIdHf6qOtFfee/o7ruH0jF5I6UAuU+19r9QV7nU3P/uI0l6+oElRHmG/5cBBcGJrD7Ozg==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.7.tgz",
+			"integrity": "sha512-Fouw4KJVWqqUVIu1gZW8BH2HakwLz6dvdrAhXeXfeymOBrZw+hcqaWs+cS1AZPVp4nlbeIujYrKA921ZW2WMPA==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6415,44 +16613,22 @@
 			}
 		},
 		"node_modules/@smithy/service-error-classification": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.6.tgz",
-			"integrity": "sha512-53SpchU3+DUZrN7J6sBx9tBiCVGzsib2e4sc512Q7K9fpC5zkJKs6Z9s+qbMxSYrkEkle6hnMtrts7XNkMJJMg==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.7.tgz",
+			"integrity": "sha512-91PRkTfiBf9hxkIchhRKJfl1rsplRDyBnmyFca3y0Z3x/q0JJN480S83LBd8R6sBCkm2bBbqw2FHp0Mbh+ecSA==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/service-error-classification/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
+				"@smithy/types": "^3.5.0"
 			},
 			"engines": {
 				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.7.tgz",
-			"integrity": "sha512-IA4K2qTJYXkF5OfVN4vsY1hfnUZjaslEE8Fsr/gGFza4TAC2A9NfnZuSY2srQIbt9bwtjHiAayrRVgKse4Q7fA==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.8.tgz",
+			"integrity": "sha512-0NHdQiSkeGl0ICQKcJQ2lCOKH23Nb0EaAa7RDRId6ZqwXkw4LJyIyZ0t3iusD4bnKYDPLGy2/5e2rfUhrt0Acw==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/shared-ini-file-loader/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6477,26 +16653,15 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.3.5.tgz",
-			"integrity": "sha512-7IZi8J3Dr9n3tX+lcpmJ/5tCYIqoXdblFBaPuv0SEKZFRpCxE+TqIWL6I3t7jLlk9TWu3JSvEZAhtjB9yvB+zA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.0.tgz",
+			"integrity": "sha512-nOfJ1nVQsxiP6srKt43r2My0Gp5PLWCW2ASqUioxIiGmu6d32v4Nekidiv5qOmmtzIrmaD+ADX5SKHUuhReeBQ==",
 			"dependencies": {
-				"@smithy/middleware-endpoint": "^3.1.3",
-				"@smithy/middleware-stack": "^3.0.6",
-				"@smithy/protocol-http": "^4.1.3",
-				"@smithy/types": "^3.4.2",
-				"@smithy/util-stream": "^3.1.8",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/smithy-client/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/middleware-endpoint": "^3.1.4",
+				"@smithy/middleware-stack": "^3.0.7",
+				"@smithy/protocol-http": "^4.1.4",
+				"@smithy/types": "^3.5.0",
+				"@smithy/util-stream": "^3.1.9",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6504,9 +16669,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-			"integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.5.0.tgz",
+			"integrity": "sha512-QN0twHNfe8mNJdH9unwsCK13GURU7oEAZqkBI+rsvpv1jrmserO+WnLE7jidR9W/1dxwZ0u/CB01mV2Gms/K2Q==",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -6515,24 +16680,13 @@
 			}
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.6.tgz",
-			"integrity": "sha512-47Op/NU8Opt49KyGpHtVdnmmJMsp2hEwBdyjuFB9M2V5QVOwA7pBhhxKN5z6ztKGrMw76gd8MlbPuzzvaAncuQ==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.7.tgz",
+			"integrity": "sha512-70UbSSR8J97c1rHZOWhl+VKiZDqHWxs/iW8ZHrHp5fCCPLSBE7GcUlUvKSle3Ca+J9LLbYCj/A79BxztBvAfpA==",
 			"dependencies": {
-				"@smithy/querystring-parser": "^3.0.6",
-				"@smithy/types": "^3.4.2",
+				"@smithy/querystring-parser": "^3.0.7",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@smithy/url-parser/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@smithy/util-base64": {
@@ -6591,13 +16745,13 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "3.0.21",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.21.tgz",
-			"integrity": "sha512-M/FhTBk4c/SsB91dD/M4gMGfJO7z/qJaM9+XQQIqBOf4qzZYMExnP7R4VdGwxxH8IKMGW+8F0I4rNtVRrcfPoA==",
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.23.tgz",
+			"integrity": "sha512-Y07qslyRtXDP/C5aWKqxTPBl4YxplEELG3xRrz2dnAQ6Lq/FgNrcKWmV561nNaZmFH+EzeGOX3ZRMbU8p1T6Nw==",
 			"dependencies": {
-				"@smithy/property-provider": "^3.1.6",
-				"@smithy/smithy-client": "^3.3.5",
-				"@smithy/types": "^3.4.2",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -6605,63 +16759,30 @@
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/@smithy/util-defaults-mode-browser/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "3.0.21",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.21.tgz",
-			"integrity": "sha512-NiLinPvF86U3S2Pdx/ycqd4bnY5dmFSPNL5KYRwbNjqQFS09M5Wzqk8BNk61/47xCYz1X/6KeiSk9qgYPTtuDw==",
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.23.tgz",
+			"integrity": "sha512-9Y4WH7f0vnDGuHUa4lGX9e2p+sMwODibsceSV6rfkZOvMC+BY3StB2LdO1NHafpsyHJLpwAgChxQ38tFyd6vkg==",
 			"dependencies": {
-				"@smithy/config-resolver": "^3.0.8",
-				"@smithy/credential-provider-imds": "^3.2.3",
-				"@smithy/node-config-provider": "^3.1.7",
-				"@smithy/property-provider": "^3.1.6",
-				"@smithy/smithy-client": "^3.3.5",
-				"@smithy/types": "^3.4.2",
+				"@smithy/config-resolver": "^3.0.9",
+				"@smithy/credential-provider-imds": "^3.2.4",
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/property-provider": "^3.1.7",
+				"@smithy/smithy-client": "^3.4.0",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/@smithy/util-defaults-mode-node/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
 		"node_modules/@smithy/util-endpoints": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.2.tgz",
-			"integrity": "sha512-FEISzffb4H8DLzGq1g4MuDpcv6CIG15fXoQzDH9SjpRJv6h7J++1STFWWinilG0tQh9H1v2UKWG19Jjr2B16zQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.3.tgz",
+			"integrity": "sha512-34eACeKov6jZdHqS5hxBMJ4KyWKztTMulhuQ2UdOoP6vVxMLrOKUqIXAwJe/wiWMhXhydLW664B02CNpQBQ4Aw==",
 			"dependencies": {
-				"@smithy/node-config-provider": "^3.1.7",
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/util-endpoints/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/node-config-provider": "^3.1.8",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6680,22 +16801,11 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.6.tgz",
-			"integrity": "sha512-BxbX4aBhI1O9p87/xM+zWy0GzT3CEVcXFPBRDoHAM+pV0eSW156pR+PSYEz0DQHDMYDsYAflC2bQNz2uaDBUZQ==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.7.tgz",
+			"integrity": "sha512-OVA6fv/3o7TMJTpTgOi1H5OTwnuUa8hzRzhSFDtZyNxi6OZ70L/FHattSmhE212I7b6WSOJAAmbYnvcjTHOJCA==",
 			"dependencies": {
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6703,23 +16813,12 @@
 			}
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.6.tgz",
-			"integrity": "sha512-BRZiuF7IwDntAbevqMco67an0Sr9oLQJqqRCsSPZZHYRnehS0LHDAkJk/pSmI7Z8c/1Vet294H7fY2fWUgB+Rg==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.7.tgz",
+			"integrity": "sha512-nh1ZO1vTeo2YX1plFPSe/OXaHkLAHza5jpokNiiKX2M5YpNUv6RxGJZhpfmiR4jSvVHCjIDmILjrxKmP+/Ghug==",
 			"dependencies": {
-				"@smithy/service-error-classification": "^3.0.6",
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/util-retry/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/service-error-classification": "^3.0.7",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6727,28 +16826,17 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.8.tgz",
-			"integrity": "sha512-hoKOqSmb8FD3WLObuB5hwbM7bNIWgcnvkThokTvVq7J5PKjlLUK5qQQcB9zWLHIoSaIlf3VIv2OxZY2wtQjcRQ==",
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.9.tgz",
+			"integrity": "sha512-7YAR0Ub3MwTMjDfjnup4qa6W8gygZMxikBhFMPESi6ASsl/rZJhwLpF/0k9TuezScCojsM0FryGdz4LZtjKPPQ==",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^3.2.8",
-				"@smithy/node-http-handler": "^3.2.3",
-				"@smithy/types": "^3.4.2",
+				"@smithy/fetch-http-handler": "^3.2.9",
+				"@smithy/node-http-handler": "^3.2.4",
+				"@smithy/types": "^3.5.0",
 				"@smithy/util-base64": "^3.0.0",
 				"@smithy/util-buffer-from": "^3.0.0",
 				"@smithy/util-hex-encoding": "^3.0.0",
 				"@smithy/util-utf8": "^3.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/util-stream/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6779,23 +16867,12 @@
 			}
 		},
 		"node_modules/@smithy/util-waiter": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.5.tgz",
-			"integrity": "sha512-jYOSvM3H6sZe3CHjzD2VQNCjWBJs+4DbtwBMvUp9y5EnnwNa7NQxTeYeQw0CKCAdGGZ3QvVkyJmvbvs5M/B10A==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.6.tgz",
+			"integrity": "sha512-xs/KAwWOeCklq8aMlnpk25LgxEYHKOEodfjfKclDMLcBJEVEKzDLxZxBQyztcuPJ7F54213NJS8PxoiHNMdItQ==",
 			"dependencies": {
-				"@smithy/abort-controller": "^3.1.4",
-				"@smithy/types": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@smithy/util-waiter/node_modules/@smithy/types": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
-			"integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
-			"dependencies": {
+				"@smithy/abort-controller": "^3.1.5",
+				"@smithy/types": "^3.5.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -7028,11 +17105,6 @@
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
 			"dev": true
 		},
-		"node_modules/@types/uuid": {
-			"version": "9.0.8",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-			"integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
-		},
 		"node_modules/@types/ws": {
 			"version": "8.5.10",
 			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
@@ -7217,6 +17289,32 @@
 				}
 			}
 		},
+		"node_modules/@whatwg-node/fetch": {
+			"version": "0.9.21",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.21.tgz",
+			"integrity": "sha512-Wt0jPb+04JjobK0pAAN7mEHxVHcGA9HoP3OyCsZtyAecNQeADXCZ1MihFwVwjsgaRYuGVmNlsCmLxlG6mor8Gw==",
+			"dependencies": {
+				"@whatwg-node/node-fetch": "^0.5.23",
+				"urlpattern-polyfill": "^10.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@whatwg-node/node-fetch": {
+			"version": "0.5.26",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.26.tgz",
+			"integrity": "sha512-4jXDeZ4IH4bylZ6wu14VEx0aDXXhrN4TC279v9rPmn08g4EYekcYf8wdcOOnS9STjDkb6x77/6xBUTqxGgjr8g==",
+			"dependencies": {
+				"@kamilkisiela/fast-url-parser": "^1.1.4",
+				"busboy": "^1.6.0",
+				"fast-querystring": "^1.1.1",
+				"tslib": "^2.6.3"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/@xtuc/ieee754": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -7377,7 +17475,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
 			"integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.5",
 				"is-array-buffer": "^3.0.4"
@@ -7395,11 +17492,35 @@
 			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
 			"dev": true
 		},
+		"node_modules/array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/array.prototype.flatmap": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+			"integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-shim-unscopables": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/arraybuffer.prototype.slice": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
 			"integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
-			"dev": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.1",
 				"call-bind": "^1.0.5",
@@ -7417,6 +17538,11 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+		},
 		"node_modules/async": {
 			"version": "2.6.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
@@ -7430,16 +17556,25 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
 			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"dev": true,
 			"engines": {
 				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/auto-bind": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+			"integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
 			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-			"dev": true,
 			"dependencies": {
 				"possible-typed-array-names": "^1.0.0"
 			},
@@ -7450,19 +17585,410 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/aws-amplify": {
-			"version": "6.6.2",
-			"resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.6.2.tgz",
-			"integrity": "sha512-VPboVLLQyyWQvpMfqrEQsF2SkVTqIKMQrEzakl01kIzyoaKKaPVefc7Gd9RmtuDuDcU/SalIR2pIRfE4ZkTMRQ==",
+		"node_modules/aws-cdk-lib": {
+			"version": "2.161.1",
+			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.161.1.tgz",
+			"integrity": "sha512-siVuWLRXD9AcQ2vkTPYbp/oH5KeXmx23voOkk/BcFmM9Sw+0kb1wgFWYCF2LMeFWDa+k5TuWMB0QtChN8/uz9A==",
+			"bundleDependencies": [
+				"@balena/dockerignore",
+				"case",
+				"fs-extra",
+				"ignore",
+				"jsonschema",
+				"minimatch",
+				"punycode",
+				"semver",
+				"table",
+				"yaml",
+				"mime-types"
+			],
+			"peer": true,
 			"dependencies": {
-				"@aws-amplify/analytics": "7.0.49",
-				"@aws-amplify/api": "6.0.51",
-				"@aws-amplify/auth": "6.4.2",
-				"@aws-amplify/core": "6.4.2",
-				"@aws-amplify/datastore": "5.0.51",
-				"@aws-amplify/notifications": "2.0.49",
-				"@aws-amplify/storage": "6.6.7",
-				"tslib": "^2.5.0"
+				"@aws-cdk/asset-awscli-v1": "^2.2.202",
+				"@aws-cdk/asset-kubectl-v20": "^2.1.2",
+				"@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+				"@aws-cdk/cloud-assembly-schema": "^38.0.0",
+				"@balena/dockerignore": "^1.0.2",
+				"case": "1.6.3",
+				"fs-extra": "^11.2.0",
+				"ignore": "^5.3.2",
+				"jsonschema": "^1.4.1",
+				"mime-types": "^2.1.35",
+				"minimatch": "^3.1.2",
+				"punycode": "^2.3.1",
+				"semver": "^7.6.3",
+				"table": "^6.8.2",
+				"yaml": "1.10.2"
+			},
+			"engines": {
+				"node": ">= 14.15.0"
+			},
+			"peerDependencies": {
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/aws-cdk-lib/node_modules/ajv": {
+			"version": "8.17.1",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/astral-regex": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/case": {
+			"version": "1.6.3",
+			"inBundle": true,
+			"license": "(MIT OR GPL-3.0-or-later)",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/color-convert": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/color-name": {
+			"version": "1.1.4",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/aws-cdk-lib/node_modules/concat-map": {
+			"version": "0.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/aws-cdk-lib/node_modules/fast-uri": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/aws-cdk-lib/node_modules/fs-extra": {
+			"version": "11.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"inBundle": true,
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/aws-cdk-lib/node_modules/ignore": {
+			"version": "5.3.2",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/aws-cdk-lib/node_modules/jsonfile": {
+			"version": "6.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/jsonschema": {
+			"version": "1.4.1",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+			"version": "4.4.2",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/aws-cdk-lib/node_modules/mime-db": {
+			"version": "1.52.0",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/mime-types": {
+			"version": "2.1.35",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/minimatch": {
+			"version": "3.1.2",
+			"inBundle": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/punycode": {
+			"version": "2.3.1",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/require-from-string": {
+			"version": "2.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/semver": {
+			"version": "7.6.3",
+			"inBundle": true,
+			"license": "ISC",
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/string-width": {
+			"version": "4.2.3",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/table": {
+			"version": "6.8.2",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"ajv": "^8.0.1",
+				"lodash.truncate": "^4.4.2",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/universalify": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/yaml": {
+			"version": "1.10.2",
+			"inBundle": true,
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/babel-generator": {
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dependencies": {
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"node_modules/babel-generator/node_modules/jsesc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"integrity": "sha512-Mke0DA0QjUWuJlhsE0ZPPhYiJkRap642SmI/4ztCFaUs6V2AiH1sfecc+57NgaryfAA2VR3v6O+CSjC1jZJKOA==",
+			"bin": {
+				"jsesc": "bin/jsesc"
+			}
+		},
+		"node_modules/babel-generator/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/babel-loader": {
@@ -7535,6 +18061,14 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
+			"dependencies": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
 			"version": "0.4.11",
 			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
@@ -7583,11 +18117,92 @@
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
+		"node_modules/babel-plugin-syntax-trailing-function-commas": {
+			"version": "7.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+			"integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+		},
+		"node_modules/babel-preset-fbjs": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+			"integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
+			"dependencies": {
+				"@babel/plugin-proposal-class-properties": "^7.0.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+				"@babel/plugin-syntax-class-properties": "^7.0.0",
+				"@babel/plugin-syntax-flow": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"@babel/plugin-transform-arrow-functions": "^7.0.0",
+				"@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+				"@babel/plugin-transform-block-scoping": "^7.0.0",
+				"@babel/plugin-transform-classes": "^7.0.0",
+				"@babel/plugin-transform-computed-properties": "^7.0.0",
+				"@babel/plugin-transform-destructuring": "^7.0.0",
+				"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+				"@babel/plugin-transform-for-of": "^7.0.0",
+				"@babel/plugin-transform-function-name": "^7.0.0",
+				"@babel/plugin-transform-literals": "^7.0.0",
+				"@babel/plugin-transform-member-expression-literals": "^7.0.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+				"@babel/plugin-transform-object-super": "^7.0.0",
+				"@babel/plugin-transform-parameters": "^7.0.0",
+				"@babel/plugin-transform-property-literals": "^7.0.0",
+				"@babel/plugin-transform-react-display-name": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+				"@babel/plugin-transform-spread": "^7.0.0",
+				"@babel/plugin-transform-template-literals": "^7.0.0",
+				"babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+			"dependencies": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			}
+		},
+		"node_modules/babel-runtime/node_modules/core-js": {
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+			"deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+			"hasInstallScript": true
+		},
+		"node_modules/babel-runtime/node_modules/regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+		},
+		"node_modules/babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+			"dependencies": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			}
+		},
+		"node_modules/babel-types/node_modules/to-fast-properties": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"node_modules/base64-arraybuffer": {
 			"version": "1.0.2",
@@ -7601,6 +18216,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -7716,7 +18332,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -7761,6 +18376,14 @@
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/bser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+			"dependencies": {
+				"node-int64": "^0.4.0"
 			}
 		},
 		"node_modules/buffer": {
@@ -7828,6 +18451,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/busboy": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+			"dependencies": {
+				"streamsearch": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			}
+		},
 		"node_modules/bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -7841,7 +18475,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
 			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-			"dev": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
@@ -7860,10 +18493,17 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
 			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-			"dev": true,
 			"dependencies": {
 				"pascal-case": "^3.1.2",
 				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/caniuse-lite": {
@@ -7885,11 +18525,20 @@
 				}
 			]
 		},
+		"node_modules/capital-case": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -7905,7 +18554,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -7920,12 +18568,55 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/change-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+			"dependencies": {
+				"camel-case": "^4.1.2",
+				"capital-case": "^1.0.4",
+				"constant-case": "^3.0.4",
+				"dot-case": "^3.0.4",
+				"header-case": "^2.0.4",
+				"no-case": "^3.0.4",
+				"param-case": "^3.0.4",
+				"pascal-case": "^3.1.2",
+				"path-case": "^3.0.4",
+				"sentence-case": "^3.0.4",
+				"snake-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/change-case-all": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+			"integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+			"dependencies": {
+				"change-case": "^4.1.2",
+				"is-lower-case": "^2.0.2",
+				"is-upper-case": "^2.0.2",
+				"lower-case": "^2.0.2",
+				"lower-case-first": "^2.0.2",
+				"sponge-case": "^1.0.1",
+				"swap-case": "^2.0.2",
+				"title-case": "^3.0.3",
+				"upper-case": "^2.0.2",
+				"upper-case-first": "^2.0.2"
+			}
+		},
+		"node_modules/charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/chokidar": {
@@ -7960,6 +18651,20 @@
 				"node": ">=6.0"
 			}
 		},
+		"node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/clean-css": {
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -7970,6 +18675,80 @@
 			},
 			"engines": {
 				"node": ">= 10.0"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/clone-deep": {
@@ -7990,7 +18769,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -8001,8 +18779,7 @@
 		"node_modules/color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
 		"node_modules/colorette": {
 			"version": "2.0.20",
@@ -8025,7 +18802,6 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
 			"integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
-			"dev": true,
 			"engines": {
 				"node": ">=4.0.0"
 			}
@@ -8069,8 +18845,7 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
 		"node_modules/connect-history-api-fallback": {
 			"version": "2.0.0",
@@ -8079,6 +18854,25 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8"
+			}
+		},
+		"node_modules/constant-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case": "^2.0.2"
+			}
+		},
+		"node_modules/constructs": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
+			"integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
+			"peer": true,
+			"engines": {
+				"node": ">= 16.14.0"
 			}
 		},
 		"node_modules/content-disposition": {
@@ -8105,8 +18899,7 @@
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-			"dev": true
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
 		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
@@ -8206,6 +18999,16 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/core-js": {
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+			"integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
+			"hasInstallScript": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
+			}
+		},
 		"node_modules/core-js-compat": {
 			"version": "3.38.1",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
@@ -8233,11 +19036,29 @@
 				"node": ">= 0.4.0"
 			}
 		},
+		"node_modules/cross-fetch": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+			"integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+			"dependencies": {
+				"node-fetch": "^2.6.12"
+			}
+		},
+		"node_modules/cross-inspect": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+			"integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"dev": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -8245,6 +19066,14 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/crypto-random-string": {
@@ -8352,7 +19181,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
 			"integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.6",
 				"es-errors": "^1.3.0",
@@ -8369,7 +19197,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
 			"integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"es-errors": "^1.3.0",
@@ -8386,7 +19213,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
 			"integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.6",
 				"es-errors": "^1.3.0",
@@ -8406,6 +19232,14 @@
 			"dev": true,
 			"dependencies": {
 				"ms": "2.0.0"
+			}
+		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/deepmerge": {
@@ -8461,7 +19295,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-			"dev": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
@@ -8490,7 +19323,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
 			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-			"dev": true,
 			"dependencies": {
 				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
@@ -8512,6 +19344,14 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/dependency-graph": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+			"integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/destroy": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -8522,11 +19362,41 @@
 				"npm": "1.2.8000 || >= 1.4.16"
 			}
 		},
+		"node_modules/detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha512-BDKtmHlOzwI7iRuEkhzsnPoi5ypEhWAJB5RvHWe1kMr06js3uK5B3734i3ui5Yd+wOJV1cpE4JnivPD283GU/A==",
+			"dependencies": {
+				"repeating": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/detect-node": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
+		},
+		"node_modules/dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dependencies": {
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/dir-glob/node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/dns-packet": {
 			"version": "5.6.1",
@@ -8619,10 +19489,17 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
 			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-			"dev": true,
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/dset": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+			"integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/eastasianwidth": {
@@ -8709,7 +19586,6 @@
 			"version": "1.23.3",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
 			"integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
-			"dev": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.1",
 				"arraybuffer.prototype.slice": "^1.0.3",
@@ -8769,7 +19645,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
 			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.2.4"
 			},
@@ -8781,7 +19656,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -8795,7 +19669,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
 			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-			"dev": true,
 			"dependencies": {
 				"es-errors": "^1.3.0"
 			},
@@ -8807,7 +19680,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
 			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
-			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.2.4",
 				"has-tostringtag": "^1.0.2",
@@ -8817,11 +19689,18 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/es-shim-unscopables": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+			"dependencies": {
+				"hasown": "^2.0.0"
+			}
+		},
 		"node_modules/es-to-primitive": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
 			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"dev": true,
 			"dependencies": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -8852,7 +19731,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -8906,7 +19784,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9005,6 +19882,11 @@
 				"node": ">= 0.10.0"
 			}
 		},
+		"node_modules/fast-decode-uri-component": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9029,6 +19911,14 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+		},
+		"node_modules/fast-querystring": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+			"integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+			"dependencies": {
+				"fast-decode-uri-component": "^1.0.1"
+			}
 		},
 		"node_modules/fast-uri": {
 			"version": "3.0.1",
@@ -9084,6 +19974,33 @@
 			"engines": {
 				"node": ">=0.8.0"
 			}
+		},
+		"node_modules/fb-watchman": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+			"dependencies": {
+				"bser": "2.1.1"
+			}
+		},
+		"node_modules/fbjs": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+			"integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
+			"dependencies": {
+				"cross-fetch": "^3.1.5",
+				"fbjs-css-vars": "^1.0.0",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^1.0.35"
+			}
+		},
+		"node_modules/fbjs-css-vars": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
 		},
 		"node_modules/file-saver": {
 			"version": "1.3.8",
@@ -9262,7 +20179,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
 			"dependencies": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
@@ -9304,7 +20220,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
 			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"dev": true,
 			"dependencies": {
 				"is-callable": "^1.1.3"
 			}
@@ -9359,7 +20274,6 @@
 			"version": "9.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
 			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-			"dev": true,
 			"dependencies": {
 				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
@@ -9373,8 +20287,7 @@
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -9394,7 +20307,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -9403,7 +20315,6 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
 			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
@@ -9421,7 +20332,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
 			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -9430,16 +20340,22 @@
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/get-intrinsic": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
 			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-			"dev": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
@@ -9476,7 +20392,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
 			"integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.5",
 				"es-errors": "^1.3.0",
@@ -9552,7 +20467,6 @@
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -9561,7 +20475,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
 			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-			"dev": true,
 			"dependencies": {
 				"define-properties": "^1.2.1",
 				"gopd": "^1.0.1"
@@ -9596,7 +20509,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
 			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.1.3"
 			},
@@ -9617,17 +20529,66 @@
 				"node": ">= 10.x"
 			}
 		},
+		"node_modules/graphql-mapping-template": {
+			"version": "4.20.16",
+			"resolved": "https://registry.npmjs.org/graphql-mapping-template/-/graphql-mapping-template-4.20.16.tgz",
+			"integrity": "sha512-J+shdngmnAxBM4mS4ga2RGusbPRMMO/TfRiNuHNKHxEU8O85us9zC6l7kSQ9hkWQDrKISJfDaesNKO3Jo5GerA=="
+		},
+		"node_modules/graphql-tag": {
+			"version": "2.12.6",
+			"resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+			"integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/graphql-transformer-common": {
+			"version": "4.31.1",
+			"resolved": "https://registry.npmjs.org/graphql-transformer-common/-/graphql-transformer-common-4.31.1.tgz",
+			"integrity": "sha512-s+C2S3PrDyuAR0ZDj9vq/DaV3ZUMf04VzacIPrc9wodvtF76Jr4E/ZzXnUAC1dKX96oK3E31W/7jilQoyZj8Rg==",
+			"dependencies": {
+				"graphql": "^15.5.0",
+				"graphql-mapping-template": "4.20.16",
+				"md5": "^2.2.1",
+				"pluralize": "8.0.0"
+			}
+		},
 		"node_modules/handle-thing": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
 			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
 			"dev": true
 		},
+		"node_modules/handlebars": {
+			"version": "4.7.7",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+			"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.0",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
+			}
+		},
 		"node_modules/has-bigints": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
 			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -9644,7 +20605,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-			"dev": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0"
 			},
@@ -9656,7 +20616,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
 			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -9668,7 +20627,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
 			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -9680,7 +20638,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dev": true,
 			"dependencies": {
 				"has-symbols": "^1.0.3"
 			},
@@ -9695,7 +20652,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
 			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -9710,6 +20666,15 @@
 			"dev": true,
 			"bin": {
 				"he": "bin/he"
+			}
+		},
+		"node_modules/header-case": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+			"dependencies": {
+				"capital-case": "^1.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/hpack.js": {
@@ -10020,6 +20985,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -10063,13 +21029,23 @@
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
 			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
 		},
-		"node_modules/immer": {
-			"version": "9.0.6",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
-			"integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+		"node_modules/immutable": {
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+			"integrity": "sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/import-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+			"integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+			"engines": {
+				"node": ">=12.2"
+			},
 			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/immer"
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/import-local": {
@@ -10091,12 +21067,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/inflected": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/inflected/-/inflected-2.1.0.tgz",
+			"integrity": "sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w=="
+		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -10111,7 +21091,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
 			"integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
-			"dev": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"hasown": "^2.0.0",
@@ -10130,6 +21109,14 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dependencies": {
+				"loose-envify": "^1.0.0"
+			}
+		},
 		"node_modules/ipaddr.js": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -10139,11 +21126,22 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/is-absolute": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+			"dependencies": {
+				"is-relative": "^1.0.0",
+				"is-windows": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-array-buffer": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
 			"integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.2.1"
@@ -10159,7 +21157,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
 			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-			"dev": true,
 			"dependencies": {
 				"has-bigints": "^1.0.1"
 			},
@@ -10183,7 +21180,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
 			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -10194,6 +21190,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"node_modules/is-builtin-module": {
 			"version": "3.2.1",
@@ -10214,12 +21215,22 @@
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-ci": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+			"dependencies": {
+				"ci-info": "^3.2.0"
+			},
+			"bin": {
+				"is-ci": "bin.js"
 			}
 		},
 		"node_modules/is-core-module": {
@@ -10238,7 +21249,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
 			"integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
-			"dev": true,
 			"dependencies": {
 				"is-typed-array": "^1.1.13"
 			},
@@ -10253,7 +21263,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
 			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-			"dev": true,
 			"dependencies": {
 				"has-tostringtag": "^1.0.0"
 			},
@@ -10287,11 +21296,21 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-finite": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -10331,6 +21350,14 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-lower-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
+			"integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -10341,7 +21368,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
 			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -10373,7 +21399,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
 			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-			"dev": true,
 			"dependencies": {
 				"has-tostringtag": "^1.0.0"
 			},
@@ -10421,7 +21446,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
 			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -10442,11 +21466,21 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-relative": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+			"dependencies": {
+				"is-unc-path": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-shared-array-buffer": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
 			"integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.7"
 			},
@@ -10473,7 +21507,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
 			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-			"dev": true,
 			"dependencies": {
 				"has-tostringtag": "^1.0.0"
 			},
@@ -10488,7 +21521,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
 			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-			"dev": true,
 			"dependencies": {
 				"has-symbols": "^1.0.2"
 			},
@@ -10503,7 +21535,6 @@
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
 			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
-			"dev": true,
 			"dependencies": {
 				"which-typed-array": "^1.1.14"
 			},
@@ -10514,16 +21545,42 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-unc-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+			"dependencies": {
+				"unc-path-regex": "^0.1.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-upper-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
+			"integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/is-weakref": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
 			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-wsl": {
@@ -10549,8 +21606,7 @@
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
 		"node_modules/isobject": {
 			"version": "3.0.1",
@@ -10663,14 +21719,6 @@
 			"integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
 			"dev": true
 		},
-		"node_modules/js-cookie": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-			"integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10680,7 +21728,6 @@
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
@@ -10708,7 +21755,6 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -10720,7 +21766,6 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
 			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dev": true,
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
@@ -10834,7 +21879,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
 			"dependencies": {
 				"p-locate": "^4.1.0"
 			},
@@ -10852,6 +21896,16 @@
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true
+		},
+		"node_modules/lodash.mergewith": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+		},
+		"node_modules/lodash.snakecase": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
 		},
 		"node_modules/lodash.sortby": {
 			"version": "4.7.0",
@@ -10874,7 +21928,14 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
 			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/lower-case-first": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-2.0.2.tgz",
+			"integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
 			"dependencies": {
 				"tslib": "^2.0.3"
 			}
@@ -10895,6 +21956,24 @@
 			"dev": true,
 			"dependencies": {
 				"sourcemap-codec": "^1.4.8"
+			}
+		},
+		"node_modules/map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
 			}
 		},
 		"node_modules/media-typer": {
@@ -11014,6 +22093,14 @@
 				"dom-walk": "^0.1.0"
 			}
 		},
+		"node_modules/min-indent": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -11024,7 +22111,6 @@
 			"version": "9.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
 			"integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -11039,7 +22125,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -11120,10 +22205,47 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
 			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"dev": true,
 			"dependencies": {
 				"lower-case": "^2.0.2",
 				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/node-fetch/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+		},
+		"node_modules/node-fetch/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+		},
+		"node_modules/node-fetch/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/node-forge": {
@@ -11134,6 +22256,11 @@
 			"engines": {
 				"node": ">= 6.13.0"
 			}
+		},
+		"node_modules/node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.18",
@@ -11172,6 +22299,11 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
+		"node_modules/nullthrows": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+			"integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -11184,7 +22316,6 @@
 			"version": "1.13.2",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
 			"integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -11196,7 +22327,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -11205,7 +22335,6 @@
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
 			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.5",
 				"define-properties": "^1.2.1",
@@ -11256,7 +22385,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -11307,7 +22435,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
 			"dependencies": {
 				"p-try": "^2.0.0"
 			},
@@ -11322,7 +22449,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
 			"dependencies": {
 				"p-limit": "^2.2.0"
 			},
@@ -11351,7 +22477,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -11371,7 +22496,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
 			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-			"dev": true,
 			"dependencies": {
 				"dot-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -11399,6 +22523,19 @@
 				"xml2js": "^0.5.0"
 			}
 		},
+		"node_modules/parse-filepath": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+			"integrity": "sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==",
+			"dependencies": {
+				"is-absolute": "^1.0.0",
+				"map-cache": "^0.2.0",
+				"path-root": "^0.1.1"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/parse-headers": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
@@ -11418,7 +22555,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
 			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-			"dev": true,
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -11430,11 +22566,19 @@
 			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
 			"dev": true
 		},
+		"node_modules/path-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+			"dependencies": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -11443,7 +22587,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11452,7 +22595,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -11462,6 +22604,25 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
+		},
+		"node_modules/path-root": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+			"integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
+			"dependencies": {
+				"path-root-regex": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-root-regex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+			"integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/path-scurry": {
 			"version": "1.11.1",
@@ -11556,6 +22717,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pluralize": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/pngjs": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
@@ -11598,7 +22767,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
 			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -11709,6 +22877,17 @@
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"dev": true
 		},
+		"node_modules/prettier": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/pretty-bytes": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -11744,6 +22923,14 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
+		"node_modules/promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dependencies": {
+				"asap": "~2.0.3"
+			}
 		},
 		"node_modules/prop-types": {
 			"version": "15.8.1",
@@ -12036,7 +23223,6 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
 			"integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.6",
 				"define-properties": "^1.2.1",
@@ -12097,6 +23283,16 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/relay-runtime": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-12.0.0.tgz",
+			"integrity": "sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==",
+			"dependencies": {
+				"@babel/runtime": "^7.0.0",
+				"fbjs": "^3.0.0",
+				"invariant": "^2.2.4"
+			}
+		},
 		"node_modules/renderkid": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -12131,6 +23327,25 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==",
+			"dependencies": {
+				"is-finite": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -12138,6 +23353,11 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
 		},
 		"node_modules/requires-port": {
 			"version": "1.0.0",
@@ -12280,7 +23500,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
 			"integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"get-intrinsic": "^1.2.4",
@@ -12297,8 +23516,7 @@
 		"node_modules/safe-array-concat/node_modules/isarray": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -12323,7 +23541,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
 			"integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.6",
 				"es-errors": "^1.3.0",
@@ -12399,10 +23616,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-			"dev": true,
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -12439,6 +23655,16 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
+		},
+		"node_modules/sentence-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.2",
@@ -12526,11 +23752,15 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-			"dev": true,
 			"dependencies": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -12547,7 +23777,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
 			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-			"dev": true,
 			"dependencies": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -12585,7 +23814,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -12597,7 +23825,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -12615,7 +23842,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
 			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"es-errors": "^1.3.0",
@@ -12635,6 +23861,11 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
+		"node_modules/signedsource": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
+			"integrity": "sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww=="
+		},
 		"node_modules/slash": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -12651,6 +23882,15 @@
 			"resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
 			"integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
 			"dev": true
+		},
+		"node_modules/snake-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+			"dependencies": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
 		},
 		"node_modules/sockjs": {
 			"version": "0.3.24",
@@ -12801,6 +24041,14 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"node_modules/sponge-case": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+			"integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/statuses": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -12808,6 +24056,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/streamsearch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+			"engines": {
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/string_decoder": {
@@ -12912,7 +24168,6 @@
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
 			"integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"define-properties": "^1.2.1",
@@ -12930,7 +24185,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
 			"integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"define-properties": "^1.2.1",
@@ -12944,7 +24198,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
 			"integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"define-properties": "^1.2.1",
@@ -13026,6 +24279,17 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/strip-indent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+			"dependencies": {
+				"min-indent": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/strnum": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
@@ -13088,6 +24352,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/swap-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+			"integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+			"dependencies": {
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/tapable": {
@@ -13213,11 +24485,18 @@
 			"integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
 			"dev": true
 		},
+		"node_modules/title-case": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+			"integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -13284,10 +24563,26 @@
 				"tslib": "2"
 			}
 		},
+		"node_modules/trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ts-dedent": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.2.0.tgz",
+			"integrity": "sha512-6zSJp23uQI+Txyz5LlXMXAHpUhY4Hi0oluXny0OgIR7g/Cromq4vDBnhtbBdyIV34g0pgwxUvnvg+jLJe4c1NA==",
+			"engines": {
+				"node": ">=6.10"
+			}
+		},
 		"node_modules/tslib": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
 		},
 		"node_modules/type-fest": {
 			"version": "0.16.0",
@@ -13318,7 +24613,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
 			"integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"es-errors": "^1.3.0",
@@ -13332,7 +24626,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
 			"integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"for-each": "^0.3.3",
@@ -13351,7 +24644,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
 			"integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
-			"dev": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.7",
@@ -13371,7 +24663,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
 			"integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"for-each": "^0.3.3",
@@ -13387,19 +24678,47 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/ulid": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
-			"integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==",
+		"node_modules/ua-parser-js": {
+			"version": "1.0.39",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.39.tgz",
+			"integrity": "sha512-k24RCVWlEcjkdOxYmVJgeD/0a1TiSpqLg+ZalVGV9lsnr4yqu0w7tX/x2xX6G4zpkgQnRf89lxuZ1wsbjXM8lw==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/ua-parser-js"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/faisalman"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/faisalman"
+				}
+			],
 			"bin": {
-				"ulid": "bin/cli.js"
+				"ua-parser-js": "script/cli.js"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/uglify-js": {
+			"version": "3.19.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+			"integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+			"optional": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
 			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-bigints": "^1.0.2",
@@ -13408,6 +24727,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/unc-path-regex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+			"integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/undici-types": {
@@ -13494,7 +24821,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
 			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
@@ -13547,6 +24873,22 @@
 				"browserslist": ">= 4.21.0"
 			}
 		},
+		"node_modules/upper-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/upper-case-first": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -13560,6 +24902,11 @@
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
 			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
 			"dev": true
+		},
+		"node_modules/urlpattern-polyfill": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+			"integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
 		},
 		"node_modules/utif": {
 			"version": "2.0.1",
@@ -13608,6 +24955,14 @@
 			],
 			"bin": {
 				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/value-or-promise": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+			"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/vary": {
@@ -14058,7 +25413,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -14073,7 +25427,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
 			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-			"dev": true,
 			"dependencies": {
 				"is-bigint": "^1.0.1",
 				"is-boolean-object": "^1.1.0",
@@ -14085,11 +25438,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
+		},
 		"node_modules/which-typed-array": {
 			"version": "1.1.15",
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
 			"integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
-			"dev": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.7",
@@ -14109,6 +25466,11 @@
 			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
 			"integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
 			"dev": true
+		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
 		},
 		"node_modules/workbox-background-sync": {
 			"version": "7.1.0",
@@ -14518,8 +25880,7 @@
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"node_modules/ws": {
 			"version": "8.17.1",
@@ -14591,11 +25952,85 @@
 				"node": ">=0.4"
 			}
 		},
+		"node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+		},
 		"node_modules/yallist": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"dev": true
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+		},
+		"node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "1.1.1",
@@ -14607,6 +26042,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.23.8",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+			"integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"@fortawesome/free-regular-svg-icons": "^6.5.2",
 		"@fortawesome/free-solid-svg-icons": "^6.5.2",
 		"@fortawesome/react-fontawesome": "^0.2.2",
-		"@aws-amplify/backend": "^6.6.2",
+		"@aws-amplify/backend": "^1.3.0",
 		"copy-webpack-plugin": "^12.0.2",
 		"html2canvas": "^1.4.1",
 		"i18next": "^23.14.0",


### PR DESCRIPTION
backend version didn't exist so have re-checked and updated - think it was an artifact from using a previous package and thought just the name needed updating but they were entirely different packages